### PR TITLE
Feature: pycodestyle

### DIFF
--- a/realtimenet/setup.cfg
+++ b/realtimenet/setup.cfg
@@ -1,0 +1,6 @@
+# Config for pycodestyle
+[pycodestyle]
+max-line-length = 120
+exclude = resources/*
+count = True
+statistics = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ docopt                  ==0.6.2       # MIT
 tensorflow              ==1.14.0
 keras                   ==2.2.4
 coremltools             ==3.3
+
+# Code style
+pycodestyle             ==2.6.0


### PR DESCRIPTION
Quickly adding `pycodestyle` to the repo (config copied from our very own FE).

This way we can call `pycodestyle` in the project root directory and check if our code is complying to the code style guideline. Helps us write clearer code :smile: 