### PR TITLE
[Video Capture] Preview mirrored video but save original

### DIFF
--- a/scripts/tools/video_capture.py
+++ b/scripts/tools/video_capture.py
@@ -47,9 +47,9 @@ def _capture_video(video_duration=0., record=False):
         frames = []
         frame_size = (640, 480)     # default frame size
         while time.time() - t < video_duration:
-            ret, frame_norm = cap.read()
-            frame = cv2.flip(frame_norm, 1)
+            ret, frame = cap.read()
             frames.append(frame.copy())
+            frame = cv2.flip(frame, 1)      # horizontal flip for video-preview
             frame_size = (frame.shape[1], frame.shape[0])
 
             if record:


### PR DESCRIPTION
## AV-3982: Preview mirrored frame while video-recording
- Ticket: [AV-3982](https://20bn.atlassian.net/browse/AV-3982)

### Developer Notes
This PR fixes the error while recording video using `video_capture.py`. Earlier, the horizontally flipped video being previewed was the one being saved as well, but that isn't the desired behavior. This PR will update that to only preview the flipped video, but record the original (unflipped) version.