### PR TITLE
Fix ID for second label radio button

### DIFF
--- a/scripts/tools/annotation/templates/up_list.html
+++ b/scripts/tools/annotation/templates/up_list.html
@@ -42,7 +42,7 @@
                         {% endif %}
                         <div class="switch-field">
                           <input type="radio" name="{{idx}}" id="{{idx}}radio-one" value=0  checked> <label for="{{idx}}radio-one">0</label>
-                          <input type="radio" name="{{idx}}"  id="{idxm}}radio-two" value=1><label for="{{idx}}radio-two">1</label>
+                          <input type="radio" name="{{idx}}" id="{{idx}}radio-two" value=1><label for="{{idx}}radio-two">1</label>
                           <input type="radio" name="{{idx}}" id="{{idx}}radio-three" value=2><label for="{{idx}}radio-three">2</label>
                         </div>
                     </div>


### PR DESCRIPTION
In the current `master` version, the `1` button isn't clickable, because the ID has a typo.