### PR TITLE
Fix annotation buttons

### DIFF
--- a/scripts/tools/annotation/templates/up_list.html
+++ b/scripts/tools/annotation/templates/up_list.html
@@ -54,7 +54,7 @@
     <input type="submit" value="Submit">
     {% endif %}
 </form>
-<form method="POST" action="/train_log_reg">
+<form method="POST" action="/train_logreg">
     <input type="hidden" id="idx2" name="idx" value="{{idx}}">
       <input type="submit" value="Retrain model">
 </form>

--- a/scripts/tools/annotation/templates/up_list.html
+++ b/scripts/tools/annotation/templates/up_list.html
@@ -58,10 +58,6 @@
     <input type="hidden" id="idx2" name="idx" value="{{idx}}">
       <input type="submit" value="Retrain model">
 </form>
-<form method="POST" action="/export_annotation">
-    <input type="hidden" id="idx3" name="idx" value="{{idx}}">
-      <input type="submit" value="Export annotations">
-</form>
 {% endblock %}
 
 


### PR DESCRIPTION
1. The link for `train_logreg` was broken
2. The "Export annotations" button seems outdated, because the `/export_annotation` endpoint no longer exists. The functionality is now probably covered by the submit button on the main form.