### PR TITLE
Add classname display overlay

### DIFF
--- a/scripts/run_calorie_estimation.py
+++ b/scripts/run_calorie_estimation.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     gender = args['--gender'] or None
     use_gpu = args['--use_gpu']
 
-    camera_id = args['--camera_id'] or 0
+    camera_id = int(args['--camera_id'] or 0)
     path_in = args['--path_in'] or None
     path_out = args['--path_out'] or None
     title = args['--title'] or None

--- a/scripts/run_custom_classifier.py
+++ b/scripts/run_custom_classifier.py
@@ -33,7 +33,7 @@ from sense.downstream_tasks.postprocess import PostprocessClassificationOutput
 if __name__ == "__main__":
     # Parse arguments
     args = docopt(__doc__)
-    camera_id = args['--camera_id'] or 0
+    camera_id = int(args['--camera_id'] or 0)
     path_in = args['--path_in'] or None
     path_out = args['--path_out'] or None
     custom_classifier = args['--custom_classifier'] or None

--- a/scripts/run_fitness_rep_counter.py
+++ b/scripts/run_fitness_rep_counter.py
@@ -31,7 +31,7 @@ from sense.downstream_tasks.postprocess import PostprocessRepCounts
 if __name__ == "__main__":
     # Parse arguments
     args = docopt(__doc__)
-    camera_id = args['--camera_id'] or 0
+    camera_id = int(args['--camera_id'] or 0)
     path_in = args['--path_in'] or None
     path_out = args['--path_out'] or None
     title = args['--title'] or None

--- a/scripts/run_fitness_tracker.py
+++ b/scripts/run_fitness_tracker.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     height = float(args['--height'])
     age = float(args['--age'])
     gender = args['--gender'] or None
-    camera_id = args['--camera_id'] or 0
+    camera_id = int(args['--camera_id'] or 0)
     path_in = args['--path_in'] or None
     path_out = args['--path_out'] or None
     title = args['--title'] or None

--- a/scripts/run_gesture_recognition.py
+++ b/scripts/run_gesture_recognition.py
@@ -30,7 +30,7 @@ from sense.downstream_tasks.postprocess import PostprocessClassificationOutput
 if __name__ == "__main__":
     # Parse arguments
     args = docopt(__doc__)
-    camera_id = args['--camera_id'] or 0
+    camera_id = int(args['--camera_id'] or 0)
     path_in = args['--path_in'] or None
     path_out = args['--path_out'] or None
     title = args['--title'] or None

--- a/sense/controller.py
+++ b/sense/controller.py
@@ -109,7 +109,8 @@ class Controller:
                 if not all(callback(prediction_postprocessed) for callback in self.callbacks):
                     break
 
-            except Exception as runtime_error:
+            except Exception as e:
+                runtime_error = e
                 break
 
             # Press escape to exit

--- a/sense/display.py
+++ b/sense/display.py
@@ -2,6 +2,7 @@ import cv2
 import numpy as np
 import time
 
+from typing import Dict
 from typing import List
 from typing import Tuple
 from typing import Optional
@@ -204,7 +205,15 @@ class DisplayClassnameOverlay(BaseDisplay):
     the name is shown and stays visible for a certain duration.
     """
 
-    def __init__(self, thresholds, duration=2, font_scale=3, thickness=2, border_size=50, **kwargs):
+    def __init__(
+            self,
+            thresholds: Dict[str, float],
+            duration: float = 2.,
+            font_scale: float = 3.,
+            thickness: int = 2,
+            border_size: int = 50,
+            **kwargs
+    ):
         """
         :param thresholds:
             Dictionary of thresholds for all classes.
@@ -228,7 +237,7 @@ class DisplayClassnameOverlay(BaseDisplay):
         self._current_class_name = None
         self._start_time = None
 
-    def _get_center_coordinates(self, img, text):
+    def _get_center_coordinates(self, img: np.ndarray, text: str):
         textsize = cv2.getTextSize(text, FONT, self.font_scale, self.thickness)[0]
 
         height, width, _ = img.shape
@@ -239,11 +248,11 @@ class DisplayClassnameOverlay(BaseDisplay):
 
         return x, y
 
-    def _display_class_name(self, img, class_name):
+    def _display_class_name(self, img: np.ndarray, class_name: str):
         pos = self._get_center_coordinates(img, class_name)
         put_text(img, class_name, position=pos, font_scale=self.font_scale, thickness=self.thickness)
 
-    def display(self, img, display_data):
+    def display(self, img: np.ndarray, display_data: dict):
         now = time.perf_counter()
 
         if self._current_class_name and now - self._start_time < self.duration:

--- a/sense/display.py
+++ b/sense/display.py
@@ -10,8 +10,14 @@ from typing import Optional
 FONT = cv2.FONT_HERSHEY_PLAIN
 
 
-def put_text(img: np.ndarray, text: str, position: Tuple[int, int],
-             color: Tuple[int, int, int] = (255, 255, 255)) -> np.ndarray:
+def put_text(
+        img: np.ndarray,
+        text: str,
+        position: Tuple[int, int],
+        font_scale: float = 1.,
+        color: Tuple[int, int, int] = (255, 255, 255),
+        thickness: int = 1
+) -> np.ndarray:
     """
     Draw a white text string on an image at a specified position and return the image.
 
@@ -21,13 +27,16 @@ def put_text(img: np.ndarray, text: str, position: Tuple[int, int],
         The text to be written.
     :param position:
         A tuple of x and y coordinates of the bottom-left corner of the text in the image.
+    :param font_scale:
+        Font scale factor for modifying the font size.
     :param color:
         A tuple for font color. For BGR, eg: (0, 255, 0) for green color.
-
+    :param thickness:
+        Thickness of the lines used to draw the text.
     :return:
         The image with the text string drawn.
     """
-    cv2.putText(img, text, position, FONT, 1, color, 1, cv2.LINE_AA)
+    cv2.putText(img, text, position, FONT, font_scale, color, thickness, cv2.LINE_AA)
     return img
 
 
@@ -99,7 +108,7 @@ class DisplayTopKClassificationOutputs(BaseDisplay):
         :param top_k:
             Number of the top classification labels to be displayed.
         :param threshold:
-            Threshhold for the output to be displayed.
+            Threshold for the output to be displayed.
         """
         super().__init__(**kwargs)
         self.top_k = top_k
@@ -181,8 +190,10 @@ class DisplayFPS(BaseDisplay):
             text_color = self.default_text_color
 
         # Show FPS on the video screen
-        put_text(img, "Camera FPS: {:.1f}".format(camera_fps), (5, img.shape[0] - self.y_offset - 20), text_color)
-        put_text(img, "Model FPS: {:.1f}".format(inference_engine_fps), (5, img.shape[0] - self.y_offset), text_color)
+        put_text(img, "Camera FPS: {:.1f}".format(camera_fps), (5, img.shape[0] - self.y_offset - 20),
+                 color=text_color)
+        put_text(img, "Model FPS: {:.1f}".format(inference_engine_fps), (5, img.shape[0] - self.y_offset),
+                 color=text_color)
 
         return img
 


### PR DESCRIPTION
This PR copies over some general changes from #64 as long as that PR is still on hold.

- Add `font_scale` and `thickness` arguments to the `put_text` method
- Add `DisplayClassnameOverlay` operation that shows detected classes as a big text overlay (see screenshot)
- Fix `int` parsing of `camera_id` in all scripts
- Fix assignment of `runtime_error` in `controller.py` (the `as` statement wasn't working as expected)

![facepalming](https://user-images.githubusercontent.com/5707898/104928513-08604400-59a3-11eb-9113-455548c8735f.png)

If you want to test the `DisplayClassnameOverlay`, add this to the `display_ops` in `run_gesture_recognition.py`:
```python
        sense.display.DisplayClassnameOverlay(
            thresholds={
                "\"Sleeping\" gesture": 0.5,
                "Covering ears": 0.5,
                "Covering eyes": 0.5,
                "Facepalming": 0.5,
                "Nodding": 0.5,
                "Putting finger to mouth": 0.5,
                "Scratching": 0.5,
                "Shaking head": 0.5,
                "Waving": 0.5,
            }
        )
```
We could even add this to the script per default if people like it.