### PR TITLE
Drop tensorflow 1

### DIFF
--- a/requirements-coreml.txt
+++ b/requirements-coreml.txt
@@ -1,5 +1,0 @@
-# package                version       license
-tensorflow              ==1.14.0       # Apache 2.0
-keras                   ==2.2.4        # Apache 2.0
-coremltools             ==3.3          # BSD 3
-h5py                    ==2.10.0       # BSD 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ simpleaudio             ==1.0.4       # MIT
 tensorflow              ==2.3.1      # Apache 2.0
 Keras                   ==2.4.3      # Apache 2.0
 
+coremltools             ==3.3          # BSD 3
+h5py                    ==2.10.0       # BSD 3
+
 # unit tests
 pycodestyle             ==2.5.0          # MIT
 pytest                  ==5.4.3          # MIT

--- a/tools/conversion/convert_to_coreml.py
+++ b/tools/conversion/convert_to_coreml.py
@@ -1100,7 +1100,7 @@ def convert(backbone_settings, classifier_settings, output_name, float32, plot_m
     elif conversion_parameters['image_scale']:
         build_args['image_scale'] = 1.0 / conversion_parameters['image_scale']
 
-    coreml_model = coremltools.converters.keras.convert(keras_file, **build_args)
+    coreml_model = coremltools.convert(keras_file, **build_args)
     coreml_model.short_description = coreml_file
     spec = coreml_model.get_spec()
 


### PR DESCRIPTION
The CoreML copnversion script requires Tensorflow 1 to run while the TFLite conversion scripts requires Tensorflow 2.

This PR drops the TF1 dependency and changes the coreml conversion to work with Tensorflow 2 instead.

Still need to confirm that the output model works correctly in iOS before this can merged.

Another open question: We still include keras from the `keras` package - but it's now completely part of `tensorflow`, so I think we can simply fix the Python imports and not install `keras` as an extra package.