### PR TITLE
[FIX] Frame flip in pre-processing causing left/right confusion

### DIFF
--- a/sense/feature_extractors/mobilenet.py
+++ b/sense/feature_extractors/mobilenet.py
@@ -192,7 +192,7 @@ class StridedInflatedMobileNetV2(RealtimeNeuralNet):
         return self.cnn(video)
 
     def preprocess(self, clip):
-        clip = clip[:, :, :, ::-1].copy()
+        clip = clip.copy()
         clip /= 255.
         clip = clip.transpose(0, 1, 4, 2, 3)
         clip = torch.Tensor(clip).float()

--- a/sense/feature_extractors/mobilenet.py
+++ b/sense/feature_extractors/mobilenet.py
@@ -192,7 +192,6 @@ class StridedInflatedMobileNetV2(RealtimeNeuralNet):
         return self.cnn(video)
 
     def preprocess(self, clip):
-        clip = clip.copy()
         clip /= 255.
         clip = clip.transpose(0, 1, 4, 2, 3)
         clip = torch.Tensor(clip).float()


### PR DESCRIPTION
This PR removes the step in the pre-processing phase which was causing a confusion between left and right labels during predictions in `gesture_recognition` and `fitness_tracker`. 