### PR TITLE
TFlite Converter: Add `--verbose` argument to show detailed log messages

### DIFF
--- a/tools/conversion/convert_to_tflite.py
+++ b/tools/conversion/convert_to_tflite.py
@@ -119,7 +119,7 @@ def convert(backbone_settings, classifier_settings, output_name, plot_model, ver
     logging.info(f"input_names {in_names}")
     logging.info(f"output_names {out_names}")
     logging.info(f"image_input_names {image_inputs}")
-    logging.info(type(keras_file))
+    logging.info(f"keras file type: {type(keras_file)}")
 
     export_keras_to_tflite(keras_file, tflite_file)
 

--- a/tools/conversion/convert_to_tflite.py
+++ b/tools/conversion/convert_to_tflite.py
@@ -139,8 +139,6 @@ if __name__ == "__main__":
     path_in = args["--path_in"]
     plot_model = args["--plot_model"]
     verbose = args["--verbose"]
-    print(verbose)
-    print("\n\n\n\n\n")
 
     backbone_settings = SUPPORTED_BACKBONE_CONVERSIONS.get(backbone_name)
     if not backbone_settings:
@@ -175,4 +173,5 @@ if __name__ == "__main__":
         classifier_settings,
         output_name,
         plot_model,
-        verbose=verbose)
+        verbose=verbose
+    )

--- a/tools/conversion/convert_to_tflite.py
+++ b/tools/conversion/convert_to_tflite.py
@@ -9,6 +9,7 @@ Usage:
                        [--path_in=PATH]
                        [--plot_model]
                        [--float32]
+                       [--verbose]
   convert_to_tflite.py (-h | --help)
 
 Options:
@@ -19,6 +20,8 @@ Options:
   --plot_model        Plot intermediate Keras model and save as image.
   --float32           Use full precision. By default, this script quantizes weights
                       to 16-bit precision.
+  --verbose           Enable detailed logging
+
   -h --help
 """
 
@@ -79,7 +82,10 @@ SUPPORTED_CLASSIFIER_CONVERSIONS = {
 }
 
 
-def convert(backbone_settings, classifier_settings, output_name, plot_model):
+def convert(backbone_settings, classifier_settings, output_name, plot_model, verbose=False):
+    if verbose:
+        logging.getLogger().setLevel(logging.INFO)
+
     output_dir = "resources/model_conversion/"
     os.makedirs(output_dir, exist_ok=True)
 
@@ -110,18 +116,18 @@ def convert(backbone_settings, classifier_settings, output_name, plot_model):
         plot(model, to_file=to_file, show_shapes=True)
         logging.info("Saved model plot to {}".format(to_file))
 
-    logging.info("input_names", in_names)
-    logging.info("output_names", out_names)
-    logging.info("image_input_names", image_inputs)
+    logging.info(f"input_names {in_names}")
+    logging.info(f"output_names {out_names}")
+    logging.info(f"image_input_names {image_inputs}")
     logging.info(type(keras_file))
 
     export_keras_to_tflite(keras_file, tflite_file)
 
     if fake_weights:
-        logging.warning("************************* Warning!! **************************")
-        logging.warning("Weights in checkpoint did not match weights required by network")
-        logging.warning("Fake weights were generated where they were needed!!!!!!!!!!!!")
-        logging.warning("************************* Warning!! **************************")
+        logging.error("************************* Warning!! **************************")
+        logging.error("Weights in checkpoint did not match weights required by network")
+        logging.error("Fake weights were generated where they were needed!!!!!!!!!!!!")
+        logging.error("************************* Warning!! **************************")
 
 
 if __name__ == "__main__":
@@ -132,6 +138,9 @@ if __name__ == "__main__":
     float32 = args["--float32"]
     path_in = args["--path_in"]
     plot_model = args["--plot_model"]
+    verbose = args["--verbose"]
+    print(verbose)
+    print("\n\n\n\n\n")
 
     backbone_settings = SUPPORTED_BACKBONE_CONVERSIONS.get(backbone_name)
     if not backbone_settings:
@@ -161,4 +170,9 @@ if __name__ == "__main__":
             "{}".format(classifier_settings["corresponding_backbone"])
         )
 
-    convert(backbone_settings, classifier_settings, output_name, plot_model)
+    convert(
+        backbone_settings,
+        classifier_settings,
+        output_name,
+        plot_model,
+        verbose=verbose)

--- a/tools/conversion/keras_converter.py
+++ b/tools/conversion/keras_converter.py
@@ -99,19 +99,19 @@ class KerasConverter:
             outputs=[self.container.all_layers[i] for i in self.container.out_index],
         )
         logging.info("done assembling model")
-        model.summary(print_fn=logging.info)
+        model.summary(print_fn=print)
 
         # logging.info() all inputs, formatted for use with coremltools Keras convertor
-        logging.info("input_names=[")
+        print("input_names = [")
         for name in self.container.in_names:
-            logging.info("  '" + name + "',")
-        logging.info("],")
+            print(f"    '{name}',")
+        print("],")
 
         # logging.info() all outputs, formatted for use with coremltools Keras convertor
-        logging.info("output_names=[")
+        print("output_names = [")
         for name in self.container.out_names:
-            logging.info("  '" + name + "',")
-        logging.info("],")
+            print(f"    '{name}',")
+        print("],")
 
         # Just for fun, logging.info() all inputs and outputs and their shapes.
 

--- a/tools/conversion/keras_converter.py
+++ b/tools/conversion/keras_converter.py
@@ -104,13 +104,13 @@ class KerasConverter:
         # logging.info() all inputs, formatted for use with coremltools Keras convertor
         logging.info("input_names=[")
         for name in self.container.in_names:
-            logging.info("'" + name + "',")
+            logging.info("  '" + name + "',")
         logging.info("],")
 
         # logging.info() all outputs, formatted for use with coremltools Keras convertor
         logging.info("output_names=[")
         for name in self.container.out_names:
-            logging.info("'" + name + "',")
+            logging.info("  '" + name + "',")
         logging.info("],")
 
         # Just for fun, logging.info() all inputs and outputs and their shapes.

--- a/tools/conversion/keras_converter.py
+++ b/tools/conversion/keras_converter.py
@@ -99,7 +99,7 @@ class KerasConverter:
             outputs=[self.container.all_layers[i] for i in self.container.out_index],
         )
         logging.info("done assembling model")
-        logging.info(model.summary())
+        model.summary(print_fn=logging.info)
 
         # logging.info() all inputs, formatted for use with coremltools Keras convertor
         logging.info("input_names=[")
@@ -118,7 +118,7 @@ class KerasConverter:
         # Inputs are actual Keras layers so we extract their names
         # also build input_features for CoreML generation
         for layer in [self.container.all_layers[i] for i in self.container.in_index]:
-            logging.info("name: ", layer.name, "; shape: ", layer.shape)
+            logging.info(f"name: {layer.name}; shape: {layer.shape}")
 
         # Outputs are not Keras layers, so we have a separate list of names for them
         # - name comes from our list,
@@ -126,7 +126,7 @@ class KerasConverter:
         out_layers = [self.container.all_layers[i] for i in self.container.out_index]
         for i in range(len(self.container.out_names)):
             logging.info(
-                "name: ", self.container.out_names[i] + "; shape: ", out_layers[i].shape
+                f"name: {self.container.out_names[i]}; shape: {out_layers[i].shape}"
             )
         return (
             model,

--- a/tools/conversion/weights_loader.py
+++ b/tools/conversion/weights_loader.py
@@ -17,6 +17,6 @@ def load_weights(backbone_ckpt, classifier_ckpt):
     weights_full = {**weights_backbone, **weights_classifier}
 
     for key in weights_full.keys():
-        logging.info(key, weights_full[key].shape)
+        logging.info(f"{key}: {weights_full[key].shape}")
 
     return weights_full


### PR DESCRIPTION
This PR adds a `--verbose` command-line argument to the TFlite conversion script. When verbose logging is enabled, we set the log level accordingly so that all log messages are shown, including `logging.info()`.

In the PR, I also changed all parameters being passed to `logging.info()` to be well-formatted strings, as logging fails if you pass multiple parameters (this is different to `print(..)` which accepts any number of parameters.

If `--verbose` is not set, the only output is the converted model summary with input and output names. Also, there are always a bunch of tensorflow prints that are unaffected by the new `--verbose` flag.

Example call:

```
python tools/conversion/convert_to_tflite.py \
--backbone=efficientnet \
--classifier=efficient_net_gesture_control \
--output_name=model-converted \
--verbose
```