### PR TITLE
README - Edit note about pytorch installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,9 @@ pip install -r requirements.txt
 ```
 
 Note: `pip install -r requirements.txt` only installs the CPU-only version of PyTorch.
-To run inference on your GPU,  another version of PyTorch should be installed. For instance:
-```shell
-conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
-``` 
-See all available options [here](https://pytorch.org/).
+To run inference on your GPU,  another version of PyTorch should be installed (e.g. 
+`conda install pytorch torchvision cudatoolkit=10.2 -c pytorch`). 
+See all available install commands [here](https://pytorch.org/).
 
 #### Step 3: Download the Pre-trained Weights
 Pre-trained weights can be downloaded from [here](https://20bn.com/licensing/sdk/evaluation). Follow the 


### PR DESCRIPTION
Problem: the README makes it look like `conda install pytorch torchvision cudatoolkit=10.2 -c pytorch` is a required installation step. 

A few `sense-iOS` users reported getting confused about this during our last hackathon.  My suggestion is to include the example install command into the `Note:` body to make it clear that this step is not mandatory.