### PR TITLE
[Feature] Save default timer settings on video-recording page

### DIFF
--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -127,6 +127,10 @@ def setup_project():
             'classes': {},
             'use_gpu': False,
             'temporal': False,
+            'video_recording': {
+                'countdown': 3,
+                'duration': 5,
+            },
         }
         old_name = None
 
@@ -310,6 +314,18 @@ def context_processors():
         return temporal_status
 
     return dict(inject_class_labels=inject_class_labels, inject_temporal_status=inject_temporal_status)
+
+
+@app.route('/set-timer-default', methods=['POST'])
+def set_timer_default():
+    data = request.json
+    path = data['path']
+    countdown = int(data['countdown'])
+    duration = int(data['duration'])
+
+    utils.set_timer_default(path, countdown, duration)
+
+    return jsonify(status=True)
 
 
 if __name__ == '__main__':

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -129,7 +129,7 @@ def setup_project():
             'temporal': False,
             'video_recording': {
                 'countdown': 3,
-                'duration': 5,
+                'recording': 5,
             },
         }
         old_name = None
@@ -321,9 +321,9 @@ def set_timer_default():
     data = request.json
     path = data['path']
     countdown = int(data['countdown'])
-    duration = int(data['duration'])
+    recording = int(data['recording'])
 
-    utils.set_timer_default(path, countdown, duration)
+    utils.set_timer_default(path, countdown, recording)
 
     return jsonify(status=True)
 

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -251,3 +251,14 @@ function toggleMakeProjectTemporal(path) {
         $('.temporal').hide();
     }
 }
+
+
+function setTimerDefault(path) {
+    let setDefaultButton = document.getElementById('setDefaultButton');
+    let countdownDuration = parseInt(document.getElementById('countdown').value);
+    let recordingDuration = parseInt(document.getElementById('duration').value);
+
+    setDefaultButton.classList.add('disabled');
+
+    response = syncRequest('/set-timer-default', {path: path, countdown: countdownDuration, duration: recordingDuration});
+}

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -261,5 +261,5 @@ function setTimerDefault(path) {
     setDefaultButton.classList.add('disabled');
     setDefaultButton.innerHTML = "Saved";
 
-    response = syncRequest('/set-timer-default', {path: path, countdown: countdownDuration, duration: recordingDuration});
+    response = syncRequest('/set-timer-default', {path: path, countdown: countdownDuration, recording: recordingDuration});
 }

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -259,6 +259,7 @@ function setTimerDefault(path) {
     let recordingDuration = parseInt(document.getElementById('duration').value);
 
     setDefaultButton.classList.add('disabled');
+    setDefaultButton.innerHTML = "Saved";
 
     response = syncRequest('/set-timer-default', {path: path, countdown: countdownDuration, duration: recordingDuration});
 }

--- a/tools/sense_studio/static/video_recording.js
+++ b/tools/sense_studio/static/video_recording.js
@@ -1,6 +1,5 @@
 
 function increase(inputID) {
-    let setDefaultButton = document.getElementById('setDefaultButton');
     let element = document.getElementById(inputID);
     let value = parseInt(element.value);
 
@@ -8,16 +7,15 @@ function increase(inputID) {
         value = 1;
     } else {
         value++;
-        setDefaultButton.classList.remove('disabled');
-        setDefaultButton.innerHTML = "Save as default"
     }
 
     element.value = value;
+
+    enableSetDefaultsButton();
 }
 
 
 function decrease(inputID, minValue) {
-    let setDefaultButton = document.getElementById('setDefaultButton');
     let element = document.getElementById(inputID);
     let value = parseInt(element.value);
 
@@ -25,11 +23,18 @@ function decrease(inputID, minValue) {
         value = 1;
     } else if (value > minValue) {
         value--;
-        setDefaultButton.classList.remove('disabled');
-        setDefaultButton.innerHTML = "Save as default"
     }
 
     element.value = value;
+
+    enableSetDefaultsButton();
+}
+
+
+function enableSetDefaultsButton() {
+    let setDefaultButton = document.getElementById('setDefaultButton');
+    setDefaultButton.classList.remove('disabled');
+    setDefaultButton.innerHTML = "Save as defaults"
 }
 
 

--- a/tools/sense_studio/static/video_recording.js
+++ b/tools/sense_studio/static/video_recording.js
@@ -1,5 +1,6 @@
 
 function increase(inputID) {
+    let setDefaultButton = document.getElementById('setDefaultButton');
     let element = document.getElementById(inputID);
     let value = parseInt(element.value);
 
@@ -7,6 +8,7 @@ function increase(inputID) {
         value = 1;
     } else {
         value++;
+        setDefaultButton.classList.remove('disabled');
     }
 
     element.value = value;
@@ -14,6 +16,7 @@ function increase(inputID) {
 
 
 function decrease(inputID, minValue) {
+    let setDefaultButton = document.getElementById('setDefaultButton');
     let element = document.getElementById(inputID);
     let value = parseInt(element.value);
 
@@ -21,6 +24,7 @@ function decrease(inputID, minValue) {
         value = 1;
     } else if (value > minValue) {
         value--;
+        setDefaultButton.classList.remove('disabled');
     }
 
     element.value = value;

--- a/tools/sense_studio/static/video_recording.js
+++ b/tools/sense_studio/static/video_recording.js
@@ -9,6 +9,7 @@ function increase(inputID) {
     } else {
         value++;
         setDefaultButton.classList.remove('disabled');
+        setDefaultButton.innerHTML = "Save as default"
     }
 
     element.value = value;
@@ -25,6 +26,7 @@ function decrease(inputID, minValue) {
     } else if (value > minValue) {
         value--;
         setDefaultButton.classList.remove('disabled');
+        setDefaultButton.innerHTML = "Save as default"
     }
 
     element.value = value;

--- a/tools/sense_studio/templates/video_recording.html
+++ b/tools/sense_studio/templates/video_recording.html
@@ -24,7 +24,7 @@
                 <label>Countdown</label>
                 <div class="ui action left icon input">
                     <i class="stopwatch icon"></i>
-                    <input type="text" value="3" id="countdown"/>
+                    <input type="text" value="{{ countdown }}" id="countdown"/>
                     <div class="ui icon button" onclick="decrease('countdown', 0);">
                         <i class="minus icon"></i>
                     </div>
@@ -37,7 +37,7 @@
                 <label>Duration</label>
                 <div class="ui action left icon input">
                     <i class="hourglass icon"></i>
-                    <input type="text" value="5" id="duration"/>
+                    <input type="text" value="{{ duration }}" id="duration"/>
                     <div class="ui icon button" onclick="decrease('duration', 1);">
                         <i class="minus icon"></i>
                     </div>
@@ -47,6 +47,11 @@
                 </div>
             </div>
         </div>
+        <div class="ui small button disabled" id="setDefaultButton" onclick="setTimerDefault('{{ path }}');">
+            <label>Set as default</label>
+        </div>
+        <br/>
+        <br/>
         <div class="ui primary icon button" id="recordVideoButton"
              onclick="recordVideo('{{ url_for('video_recording_bp.save_video', project=project, label=label, split=split) }}');">
             <i class="circle icon"></i>

--- a/tools/sense_studio/templates/video_recording.html
+++ b/tools/sense_studio/templates/video_recording.html
@@ -48,7 +48,7 @@
             </div>
         </div>
         <div class="ui small button disabled" id="setDefaultButton" onclick="setTimerDefault('{{ path }}');">
-            <label>Set as default</label>
+            <label>Save as default</label>
         </div>
         <br/>
         <br/>

--- a/tools/sense_studio/templates/video_recording.html
+++ b/tools/sense_studio/templates/video_recording.html
@@ -47,11 +47,11 @@
                 </div>
             </div>
         </div>
-        <div class="ui small button disabled" id="setDefaultButton" onclick="setTimerDefault('{{ path }}');">
-            <label>Save as default</label>
+        <div class="field">
+            <div class="ui small button disabled" id="setDefaultButton" onclick="setTimerDefault('{{ path }}');">
+                Save as defaults
+            </div>
         </div>
-        <br/>
-        <br/>
         <div class="ui primary icon button" id="recordVideoButton"
              onclick="recordVideo('{{ url_for('video_recording_bp.save_video', project=project, label=label, split=split) }}');">
             <i class="circle icon"></i>

--- a/tools/sense_studio/templates/video_recording.html
+++ b/tools/sense_studio/templates/video_recording.html
@@ -37,7 +37,7 @@
                 <label>Duration</label>
                 <div class="ui action left icon input">
                     <i class="hourglass icon"></i>
-                    <input type="text" value="{{ duration }}" id="duration"/>
+                    <input type="text" value="{{ recording }}" id="duration"/>
                     <div class="ui icon button" onclick="decrease('duration', 1);">
                         <i class="minus icon"></i>
                     </div>

--- a/tools/sense_studio/utils.py
+++ b/tools/sense_studio/utils.py
@@ -112,21 +112,21 @@ def toggle_project_setting(path, setting):
 
 
 def get_timer_default(path):
-    """Get the default countdown and duration (in seconds) for video-recording."""
+    """Get the default countdown and recording duration (in seconds) for video-recording."""
     config = load_project_config(path)
     countdown = config.get('video_recording', {}).get('countdown', 3)
-    duration = config.get('video_recording', {}).get('duration', 5)
+    duration = config.get('video_recording', {}).get('recording', 5)
 
     return countdown, duration
 
 
-def set_timer_default(path, countdown, duration):
-    """Set the new default countdown and duration (in seconds) for video-recording."""
+def set_timer_default(path, countdown, recording):
+    """Set the new default countdown and recording duration (in seconds) for video-recording."""
     config = load_project_config(path)
     video_recording = config.get('video_recording', {})
 
     video_recording['countdown'] = countdown
-    video_recording['duration'] = duration
+    video_recording['recording'] = recording
     config['video_recording'] = video_recording
 
     write_project_config(path, config)

--- a/tools/sense_studio/utils.py
+++ b/tools/sense_studio/utils.py
@@ -109,3 +109,24 @@ def toggle_project_setting(path, setting):
     write_project_config(path, config)
 
     return new_status
+
+
+def get_timer_default(path):
+    """Get the default countdown and duration (in seconds) for video-recording."""
+    config = load_project_config(path)
+    countdown = config.get('video_recording', {}).get('countdown', 3)
+    duration = config.get('video_recording', {}).get('duration', 5)
+
+    return countdown, duration
+
+
+def set_timer_default(path, countdown, duration):
+    """Set the new default countdown and duration (in seconds) for video-recording."""
+    config = load_project_config(path)
+    video_recording = config.get('video_recording', {})
+
+    video_recording['countdown'] = countdown
+    video_recording['duration'] = duration
+    config['video_recording'] = video_recording
+
+    write_project_config(path, config)

--- a/tools/sense_studio/video_recording.py
+++ b/tools/sense_studio/video_recording.py
@@ -23,7 +23,11 @@ def record_video(project, split, label):
     split = urllib.parse.unquote(split)
     label = urllib.parse.unquote(label)
     path = utils.lookup_project_path(project)
-    return render_template('video_recording.html', project=project, split=split, label=label, path=path)
+
+    countdown, duration = utils.get_timer_default(path)
+
+    return render_template('video_recording.html', project=project, split=split, label=label, path=path,
+                           countdown=countdown, duration=duration)
 
 
 @video_recording_bp.route('/save-video/<string:project>/<string:split>/<string:label>', methods=['POST'])

--- a/tools/sense_studio/video_recording.py
+++ b/tools/sense_studio/video_recording.py
@@ -24,10 +24,10 @@ def record_video(project, split, label):
     label = urllib.parse.unquote(label)
     path = utils.lookup_project_path(project)
 
-    countdown, duration = utils.get_timer_default(path)
+    countdown, recording = utils.get_timer_default(path)
 
     return render_template('video_recording.html', project=project, split=split, label=label, path=path,
-                           countdown=countdown, duration=duration)
+                           countdown=countdown, recording=recording)
 
 
 @video_recording_bp.route('/save-video/<string:project>/<string:split>/<string:label>', methods=['POST'])


### PR DESCRIPTION
This PR is associated with [this ticket](https://20bn.atlassian.net/browse/AV-4410) and adds a countdown and recording duration in the project config, and has a button to "Save as default".

The project config will now have the following structure:
```
{
    "name": ...,
    "date": ...,
    "classes": ...,
    "temporal": ...,
    "use_gpu": ...,
--> "video_recording": {
        "countdown": 5,
        "recording": 3
    }
}
```