### PR TITLE
[Feature] Add filter to video-list page (UI-kit)

### DIFF
--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -61,9 +61,13 @@ def show_video_list(project, split, label):
     tagged_list = set(os.listdir(tags_dir))
     tagged = [f'{video}.json' in tagged_list for video in videos]
 
+    num_videos = len(videos)
+    num_tagged = len(tagged_list)
+    num_untagged = num_videos - num_tagged
+
     video_list = zip(videos, tagged, list(range(len(videos))))
     return render_template('video_list.html', video_list=video_list, split=split, label=label, path=path,
-                           project=project)
+                           project=project, num_videos=num_videos, num_tagged=num_tagged, num_untagged=num_untagged)
 
 
 @annotation_bp.route('/prepare-annotation/<string:project>')

--- a/tools/sense_studio/templates/video_list.html
+++ b/tools/sense_studio/templates/video_list.html
@@ -12,7 +12,7 @@
 
 {% block main %}
 <div class="uk-container uk-container-xsmall">
-    <h1 class="uk-heading-divider uk-margin-large-top uk-margin-remove-bottom">Video Annotation</h1>
+    <h1 class="uk-heading-medium uk-margin-large-top uk-margin-remove-bottom">Video Annotation</h1>
     <div class="uk-text-meta uk-text-large uk-margin-medium-bottom">
         <span uk-icon="icon: folder"></span> {{ path }}
         <br>

--- a/tools/sense_studio/templates/video_list.html
+++ b/tools/sense_studio/templates/video_list.html
@@ -20,18 +20,16 @@
         <br>
         <span uk-icon="icon: git-fork"></span> {{ split }}
     </div>
-    <div uk-filter="target: .js-filter">
+    <div uk-filter="target: .video-list">
         <div class="uk-flex uk-flex-center">
-            <div class="uk-text-center uk-width-auto">
-                <ul class="uk-subnav uk-subnav-pill">
-                    <li class="uk-text-large uk-text-bold uk-margin">Filter</li>
-                    <li uk-filter-control><a href="#">All</a></li>
-                    <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>
-                    <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>
-                </ul>
-            </div>
+            <ul class="uk-subnav uk-subnav-pill">
+                <li class="uk-text-large uk-text-bold uk-margin">Filter</li>
+                <li uk-filter-control><a href="#">All</a></li>
+                <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>
+                <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>
+            </ul>
         </div>
-        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-width-auto uk-text-medium uk-align-right">
+        <table class="uk-box-shadow-medium uk-background-muted uk-table uk-table-small uk-width-auto uk-text-medium uk-align-right">
             <tr>
                 <td class="uk-text-bold">Total</td>
                 <td class="uk-text-right uk-text-light">{{ num_videos }}</td>
@@ -45,7 +43,7 @@
                 <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>
             </tr>
         </table>
-        <div class="js-filter uk-grid-small uk-child-width-1-1" uk-grid>
+        <div class="video-list uk-grid-small uk-child-width-1-1" uk-grid>
             {% for video, tagged, id in video_list %}
             <div class="{{ 'video-tagged' if tagged else 'video-untagged' }}">
                 <a class="uk-card uk-card-body uk-card-default uk-card-small uk-card-hover uk-link-toggle"

--- a/tools/sense_studio/templates/video_list.html
+++ b/tools/sense_studio/templates/video_list.html
@@ -12,7 +12,7 @@
 
 {% block main %}
 <div class="uk-container uk-container-xsmall">
-    <h1 class="uk-heading-medium uk-margin-large-top uk-margin-remove-bottom">Video Annotation</h1>
+    <h1 class="uk-heading-divider uk-margin-large-top uk-margin-remove-bottom">Video Annotation</h1>
     <div class="uk-text-meta uk-text-large uk-margin-medium-bottom">
         <span uk-icon="icon: folder"></span> {{ path }}
         <br>
@@ -21,25 +21,35 @@
         <span uk-icon="icon: git-fork"></span> {{ split }}
     </div>
 
-    <div class="uk-grid-small uk-child-width-1-1" uk-grid>
-        {% for video, tagged, id in video_list %}
-        <div>
-            <a class="uk-card uk-card-body uk-card-default uk-card-small uk-card-hover uk-link-toggle"
-               href="{{ url_for('annotation_bp.annotate', project=project, split=split, label=label, idx=id) }}">
-                <div class="uk-link-heading" uk-grid>
-                    <div class="uk-width-expand">
-                        <span uk-icon="icon: play"></span>
-                        {{ video }}
-                    </div>
-                    {% if tagged %}
-                    <div class="uk-width-auto">
-                        <span uk-icon="icon: check"></span>
-                    </div>
-                    {% endif %}
-                </div>
-            </a>
+    <div uk-filter="target: .js-filter">
+        <div class="uk-text-center">
+            <ul class="uk-subnav uk-subnav-pill uk-align-right">
+                <li class="uk-text-large uk-text-bolder uk-margin">Sort By</li>
+                <li uk-filter-control><a href="#">Default</a></li>
+                <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>
+                <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>
+            </ul>
         </div>
-        {% endfor %}
+        <div class="js-filter uk-grid-small uk-child-width-1-1" uk-grid>
+            {% for video, tagged, id in video_list %}
+            <div class="{{ 'video-tagged' if tagged else 'video-untagged' }}">
+                <a class="uk-card uk-card-body uk-card-default uk-card-small uk-card-hover uk-link-toggle"
+                   href="{{ url_for('annotation_bp.annotate', project=project, split=split, label=label, idx=id) }}">
+                    <div class="uk-link-heading" uk-grid>
+                        <div class="uk-width-expand">
+                            <span uk-icon="icon: play"></span>
+                            {{ video }}
+                        </div>
+                        {% if tagged %}
+                        <div class="uk-width-auto">
+                            <span uk-icon="icon: check"></span>
+                        </div>
+                        {% endif %}
+                    </div>
+                </a>
+            </div>
+            {% endfor %}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/tools/sense_studio/templates/video_list.html
+++ b/tools/sense_studio/templates/video_list.html
@@ -21,6 +21,97 @@
         <span uk-icon="icon: git-fork"></span> {{ split }}
     </div>
 
+<!--    <div class="uk-align-center uk-grid-medium uk-width-auto@m uk-margin-bottom-large" uk-grid>-->
+<!--        <h1 class="uk-text-meta uk-text-large uk-heading-line uk-text-center uk-padding-remove uk-margin-remove"><span><label class="uk-text-bold">Total : </label><label class="uk-text-lighter">{{ num_videos }}</label></span></h1>-->
+<!--        <h1 class="uk-text-meta uk-text-large uk-heading-line uk-text-center uk-padding-remove uk-margin-remove"><span><label class="uk-text-bold">Tagged : </label><label class="uk-text-lighter">{{ num_tagged }}</label></span></h1>-->
+<!--        <h1 class="uk-text-meta uk-text-large uk-heading-line uk-text-center uk-padding-remove uk-margin-remove"><span><label class="uk-text-bold">Untagged : </label><label class="uk-text-lighter">{{ num_untagged }}</label></span></h1>-->
+<!--    </div>-->
+
+<!--    <div class="uk-flex uk-flex-center">-->
+<!--        <table class="uk-box-shadow-large uk-table uk-table-small uk-width-large uk-text-large uk-table-divider uk-table-striped">-->
+<!--            <tr>-->
+<!--                <td class="uk-text-center uk-text-bold">Total</td>-->
+<!--                <td class="uk-text-center uk-text-light">{{ num_videos }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-center uk-text-bold">Tagged</td>-->
+<!--                <td class="uk-text-center uk-text-light">{{ num_tagged }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-center uk-text-bold">Untagged</td>-->
+<!--                <td class="uk-text-center uk-text-light">{{ num_untagged }}</td>-->
+<!--            </tr>-->
+<!--        </table>-->
+<!--    </div>-->
+
+<!--    <div class="uk-flex uk-flex-center">-->
+<!--        <table class="uk-box-shadow-large uk-table uk-table-small uk-width-large uk-text-large uk-table-divider">-->
+<!--            <tr>-->
+<!--                <td class="uk-text-center uk-text-bold">Total</td>-->
+<!--                <td class="uk-text-center uk-text-light">{{ num_videos }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-center uk-text-bold">Tagged</td>-->
+<!--                <td class="uk-text-center uk-text-light">{{ num_tagged }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-center uk-text-bold">Untagged</td>-->
+<!--                <td class="uk-text-center uk-text-light">{{ num_untagged }}</td>-->
+<!--            </tr>-->
+<!--        </table>-->
+<!--    </div>-->
+
+<!--    <div class="uk-flex uk-flex-center">-->
+<!--        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-table-divider uk-width-large uk-text-large">-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Total</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Tagged</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Untagged</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
+<!--            </tr>-->
+<!--        </table>-->
+<!--    </div>-->
+
+<!--    <div class="uk-flex uk-flex-center">-->
+<!--        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-table-divider uk-width-small uk-text-large">-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Total</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Tagged</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Untagged</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
+<!--            </tr>-->
+<!--        </table>-->
+<!--    </div>-->
+
+<!--    <div class="uk-flex uk-flex-center">-->
+<!--        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-table-divider uk-text-large">-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Total</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Tagged</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
+<!--            </tr>-->
+<!--            <tr>-->
+<!--                <td class="uk-text-bold">Untagged</td>-->
+<!--                <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
+<!--            </tr>-->
+<!--        </table>-->
+<!--    </div>-->
+
     <div uk-filter="target: .js-filter">
         <div class="uk-text-center">
             <ul class="uk-subnav uk-subnav-pill uk-align-right">

--- a/tools/sense_studio/templates/video_list.html
+++ b/tools/sense_studio/templates/video_list.html
@@ -115,8 +115,8 @@
     <div uk-filter="target: .js-filter">
         <div class="uk-text-center">
             <ul class="uk-subnav uk-subnav-pill uk-align-right">
-                <li class="uk-text-large uk-text-bolder uk-margin">Sort By</li>
-                <li uk-filter-control><a href="#">Default</a></li>
+                <li class="uk-text-large uk-text-bolder uk-margin">Filter</li>
+                <li uk-filter-control><a href="#">All</a></li>
                 <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>
                 <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>
             </ul>

--- a/tools/sense_studio/templates/video_list.html
+++ b/tools/sense_studio/templates/video_list.html
@@ -113,14 +113,58 @@
 <!--    </div>-->
 
     <div uk-filter="target: .js-filter">
-        <div class="uk-text-center">
-            <ul class="uk-subnav uk-subnav-pill uk-align-right">
-                <li class="uk-text-large uk-text-bolder uk-margin">Filter</li>
-                <li uk-filter-control><a href="#">All</a></li>
-                <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>
-                <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>
-            </ul>
+        <div class="uk-flex uk-flex-center">
+            <div class="uk-text-center uk-width-auto">
+                <ul class="uk-subnav uk-subnav-pill">
+                    <li class="uk-text-large uk-text-bold uk-margin">Filter</li>
+                    <li uk-filter-control><a href="#">All</a></li>
+                    <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>
+                    <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>
+                </ul>
+            </div>
         </div>
+        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-width-auto uk-text-medium uk-align-right">
+            <tr>
+                <td class="uk-text-bold">Total</td>
+                <td class="uk-text-right uk-text-light">{{ num_videos }}</td>
+            </tr>
+            <tr>
+                <td class="uk-text-bold">Tagged</td>
+                <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>
+            </tr>
+            <tr>
+                <td class="uk-text-bold">Untagged</td>
+                <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>
+            </tr>
+        </table>
+<!--        <div class="uk-align-right uk-grid-collapse" uk-grid>-->
+<!--            <div class="uk-flex uk-flex-center">-->
+<!--                <div class="uk-text-center uk-width-auto">-->
+<!--                    <ul class="uk-subnav uk-subnav-pill">-->
+<!--                        <li class="uk-text-large uk-text-bold uk-margin">Filter</li>-->
+<!--                        <li uk-filter-control><a href="#">All</a></li>-->
+<!--                        <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>-->
+<!--                        <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>-->
+<!--                    </ul>-->
+<!--                </div>-->
+<!--            </div>-->
+<!--            <div class="uk-flex uk-flex-center">-->
+<!--                <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-width-auto uk-text-medium">-->
+<!--                    <tr>-->
+<!--                        <td class="uk-text-bold">Total</td>-->
+<!--                        <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
+<!--                    </tr>-->
+<!--                    <tr>-->
+<!--                        <td class="uk-text-bold">Tagged</td>-->
+<!--                        <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
+<!--                    </tr>-->
+<!--                    <tr>-->
+<!--                        <td class="uk-text-bold">Untagged</td>-->
+<!--                        <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
+<!--                    </tr>-->
+<!--                </table>-->
+<!--            </div>-->
+<!--        </div>-->
         <div class="js-filter uk-grid-small uk-child-width-1-1" uk-grid>
             {% for video, tagged, id in video_list %}
             <div class="{{ 'video-tagged' if tagged else 'video-untagged' }}">

--- a/tools/sense_studio/templates/video_list.html
+++ b/tools/sense_studio/templates/video_list.html
@@ -20,98 +20,6 @@
         <br>
         <span uk-icon="icon: git-fork"></span> {{ split }}
     </div>
-
-<!--    <div class="uk-align-center uk-grid-medium uk-width-auto@m uk-margin-bottom-large" uk-grid>-->
-<!--        <h1 class="uk-text-meta uk-text-large uk-heading-line uk-text-center uk-padding-remove uk-margin-remove"><span><label class="uk-text-bold">Total : </label><label class="uk-text-lighter">{{ num_videos }}</label></span></h1>-->
-<!--        <h1 class="uk-text-meta uk-text-large uk-heading-line uk-text-center uk-padding-remove uk-margin-remove"><span><label class="uk-text-bold">Tagged : </label><label class="uk-text-lighter">{{ num_tagged }}</label></span></h1>-->
-<!--        <h1 class="uk-text-meta uk-text-large uk-heading-line uk-text-center uk-padding-remove uk-margin-remove"><span><label class="uk-text-bold">Untagged : </label><label class="uk-text-lighter">{{ num_untagged }}</label></span></h1>-->
-<!--    </div>-->
-
-<!--    <div class="uk-flex uk-flex-center">-->
-<!--        <table class="uk-box-shadow-large uk-table uk-table-small uk-width-large uk-text-large uk-table-divider uk-table-striped">-->
-<!--            <tr>-->
-<!--                <td class="uk-text-center uk-text-bold">Total</td>-->
-<!--                <td class="uk-text-center uk-text-light">{{ num_videos }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-center uk-text-bold">Tagged</td>-->
-<!--                <td class="uk-text-center uk-text-light">{{ num_tagged }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-center uk-text-bold">Untagged</td>-->
-<!--                <td class="uk-text-center uk-text-light">{{ num_untagged }}</td>-->
-<!--            </tr>-->
-<!--        </table>-->
-<!--    </div>-->
-
-<!--    <div class="uk-flex uk-flex-center">-->
-<!--        <table class="uk-box-shadow-large uk-table uk-table-small uk-width-large uk-text-large uk-table-divider">-->
-<!--            <tr>-->
-<!--                <td class="uk-text-center uk-text-bold">Total</td>-->
-<!--                <td class="uk-text-center uk-text-light">{{ num_videos }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-center uk-text-bold">Tagged</td>-->
-<!--                <td class="uk-text-center uk-text-light">{{ num_tagged }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-center uk-text-bold">Untagged</td>-->
-<!--                <td class="uk-text-center uk-text-light">{{ num_untagged }}</td>-->
-<!--            </tr>-->
-<!--        </table>-->
-<!--    </div>-->
-
-<!--    <div class="uk-flex uk-flex-center">-->
-<!--        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-table-divider uk-width-large uk-text-large">-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Total</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Tagged</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Untagged</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
-<!--            </tr>-->
-<!--        </table>-->
-<!--    </div>-->
-
-<!--    <div class="uk-flex uk-flex-center">-->
-<!--        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-table-divider uk-width-small uk-text-large">-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Total</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Tagged</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Untagged</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
-<!--            </tr>-->
-<!--        </table>-->
-<!--    </div>-->
-
-<!--    <div class="uk-flex uk-flex-center">-->
-<!--        <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-table-divider uk-text-large">-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Total</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Tagged</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
-<!--            </tr>-->
-<!--            <tr>-->
-<!--                <td class="uk-text-bold">Untagged</td>-->
-<!--                <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
-<!--            </tr>-->
-<!--        </table>-->
-<!--    </div>-->
-
     <div uk-filter="target: .js-filter">
         <div class="uk-flex uk-flex-center">
             <div class="uk-text-center uk-width-auto">
@@ -137,34 +45,6 @@
                 <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>
             </tr>
         </table>
-<!--        <div class="uk-align-right uk-grid-collapse" uk-grid>-->
-<!--            <div class="uk-flex uk-flex-center">-->
-<!--                <div class="uk-text-center uk-width-auto">-->
-<!--                    <ul class="uk-subnav uk-subnav-pill">-->
-<!--                        <li class="uk-text-large uk-text-bold uk-margin">Filter</li>-->
-<!--                        <li uk-filter-control><a href="#">All</a></li>-->
-<!--                        <li uk-filter-control=".video-tagged"><a href="#">Tagged</a></li>-->
-<!--                        <li uk-filter-control=".video-untagged"><a href="#">Untagged</a></li>-->
-<!--                    </ul>-->
-<!--                </div>-->
-<!--            </div>-->
-<!--            <div class="uk-flex uk-flex-center">-->
-<!--                <table class="uk-box-shadow-large uk-background-muted uk-table uk-table-small uk-width-auto uk-text-medium">-->
-<!--                    <tr>-->
-<!--                        <td class="uk-text-bold">Total</td>-->
-<!--                        <td class="uk-text-right uk-text-light">{{ num_videos }}</td>-->
-<!--                    </tr>-->
-<!--                    <tr>-->
-<!--                        <td class="uk-text-bold">Tagged</td>-->
-<!--                        <td class="uk-text-right uk-text-light">{{ num_tagged }}</td>-->
-<!--                    </tr>-->
-<!--                    <tr>-->
-<!--                        <td class="uk-text-bold">Untagged</td>-->
-<!--                        <td class="uk-text-right uk-text-light">{{ num_untagged }}</td>-->
-<!--                    </tr>-->
-<!--                </table>-->
-<!--            </div>-->
-<!--        </div>-->
         <div class="js-filter uk-grid-small uk-child-width-1-1" uk-grid>
             {% for video, tagged, id in video_list %}
             <div class="{{ 'video-tagged' if tagged else 'video-untagged' }}">


### PR DESCRIPTION
This PR addresses [this ticket](https://20bn.atlassian.net/browse/AV-4413) and adds a filter option to the list of videos on the `Video Annotation` page. Additionally, it adds a view to display the number of "total", "tagged" and "untagged" videos for the given class, label and split.