### PR TITLE
Split new project / import and use project name as folder name

### DIFF
--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -20,6 +20,7 @@ from sklearn.linear_model import LogisticRegression
 from sense import SPLITS
 from sense.finetuning import compute_frames_features
 from tools import directories
+from tools.sense_studio import project_utils
 from tools.sense_studio import utils
 
 
@@ -33,7 +34,7 @@ def show_video_list(project, split, label):
     If the necessary files for annotation haven't been prepared yet, this is done now.
     """
     project = urllib.parse.unquote(project)
-    path = utils.lookup_project_path(project)
+    path = project_utils.lookup_project_path(project)
     split = urllib.parse.unquote(split)
     label = urllib.parse.unquote(label)
 
@@ -72,7 +73,7 @@ def prepare_annotation(project):
     Prepare all files needed for annotating the videos in the given project.
     """
     project = urllib.parse.unquote(project)
-    dataset_path = utils.lookup_project_path(project)
+    dataset_path = project_utils.lookup_project_path(project)
 
     # load feature extractor
     inference_engine, model_config = utils.load_feature_extractor(dataset_path)
@@ -98,7 +99,7 @@ def annotate(project, split, label, idx):
     For the given class label, show all frames for annotating the selected video.
     """
     project = urllib.parse.unquote(project)
-    path = utils.lookup_project_path(project)
+    path = project_utils.lookup_project_path(project)
     label = urllib.parse.unquote(label)
     split = urllib.parse.unquote(split)
 
@@ -141,7 +142,7 @@ def annotate(project, split, label, idx):
             annotations = data['time_annotation']
 
     # Read tags from config
-    config = utils.load_project_config(path)
+    config = project_utils.load_project_config(path)
     tags = config['classes'][label]
     show_logreg = config.get('show_logreg', False)
 
@@ -255,6 +256,6 @@ def download_file(project, split, label, video_name, img_file):
     """
     Load an image from the given path.
     """
-    dataset_path = utils.lookup_project_path(project)
+    dataset_path = project_utils.lookup_project_path(project)
     img_dir = os.path.join(directories.get_frames_dir(dataset_path, split, label), video_name)
     return send_from_directory(img_dir, img_file, as_attachment=True)

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -1,0 +1,121 @@
+import datetime
+import json
+import os
+
+from sense import SPLITS
+from tools import directories
+
+MODULE_DIR = os.path.dirname(__file__)
+PROJECTS_OVERVIEW_CONFIG_FILE = os.path.join(MODULE_DIR, 'projects_config.json')
+
+PROJECT_CONFIG_FILE = 'project_config.json'
+
+
+def load_project_overview_config():
+    if os.path.isfile(PROJECTS_OVERVIEW_CONFIG_FILE):
+        with open(PROJECTS_OVERVIEW_CONFIG_FILE, 'r') as f:
+            projects = json.load(f)
+        return projects
+    else:
+        write_project_overview_config({})
+        return {}
+
+
+def write_project_overview_config(projects):
+    with open(PROJECTS_OVERVIEW_CONFIG_FILE, 'w') as f:
+        json.dump(projects, f, indent=2)
+
+
+def lookup_project_path(project_name):
+    projects = load_project_overview_config()
+    return projects[project_name]['path']
+
+
+def load_project_config(path):
+    config_path = os.path.join(path, PROJECT_CONFIG_FILE)
+    with open(config_path, 'r') as f:
+        config = json.load(f)
+    return config
+
+
+def write_project_config(path, config):
+    config_path = os.path.join(path, PROJECT_CONFIG_FILE)
+    with open(config_path, 'w') as f:
+        json.dump(config, f, indent=2)
+
+
+def setup_new_project(project_name, path, config=None):
+    """
+    Setup a project directory with a config file and the directories for train and valid videos and
+    add an entry to the projects overview config.
+    If an existing project config is given, this one will be used and the project name in there will
+    be updated.
+    """
+    if not config:
+        # Setup new project config
+        config = {
+            'name': project_name,
+            'date_created': datetime.date.today().isoformat(),
+            'classes': {},
+            'use_gpu': False,
+            'temporal': False,
+            'show_logreg': False,
+        }
+    else:
+        config['name'] = project_name
+
+    write_project_config(path, config)
+
+    # Setup directory structure
+    for split in SPLITS:
+        videos_dir = directories.get_videos_dir(path, split)
+        if not os.path.exists(videos_dir):
+            os.mkdir(videos_dir)
+
+    # Update overall projects config file
+    projects = load_project_overview_config()
+    projects[project_name] = {
+        'path': path,
+    }
+
+    write_project_overview_config(projects)
+
+    return config
+
+
+def get_folder_name_for_project(project_name):
+    """
+    Construct a folder name from the given project name by converting to lower case and replacing
+    spaces with underscores: My Project -> my_project
+    """
+    return project_name.lower().replace(' ', '_')
+
+
+def get_unique_project_name(base_name):
+    """
+    Make the given project name unique by adding a suffix such as "(2)" if necessary.
+    """
+    projects = load_project_overview_config()
+    project_name = base_name
+    idx = 2
+    while project_name in projects:
+        project_name = f'{base_name} ({idx})'
+        idx += 1
+
+    return project_name
+
+
+def get_project_setting(path, setting):
+    config = load_project_config(path)
+    return config.get(setting, False)
+
+
+def toggle_project_setting(path, setting):
+    config = load_project_config(path)
+    current_status = config.get(setting, False)
+
+    new_status = not current_status
+    config[setting] = new_status
+    write_project_config(path, config)
+
+    return new_status

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -112,7 +112,7 @@ def setup_project():
     Add a new project to the config file. Can also be used for updating an existing project.
     """
     data = request.form
-    name = data['projectName']
+    name = data.get('projectName')
     path = data['path']
 
     # Initialize project directory

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -1,21 +1,37 @@
+// Suppress Enter key on text input fields for submitting forms, so that for example search fields don't submit
+// the form on selection of an entry
+window.addEventListener(
+    'keydown',
+    function(e) {
+        if ((e.keyIdentifier=='U+000A' || e.keyIdentifier=='Enter' || e.keyCode==13)
+            && e.target.nodeName=='INPUT' && e.target.type=='text')
+        {
+            e.preventDefault();
+            return false;
+        }
+    },
+    true
+);
+
 
 $(document).ready(function () {
-    $('.path-search').search({
-        apiSettings: {
-            response: function (e) {
-                let path = this.children[1].value;
-                let response = browseDirectory(path);
-
-                let results = [];
-                for (const subdir of response.subdirs) {
-                    results.push({title: subdir})
-                }
-
-                return {results: results}
-            }
+    new autoComplete({
+        selector: '.path-search',
+        minChars: 1,
+        cache: false,
+        source: function(term, response) {
+            let directoriesResponse = browseDirectory(term, '');
+            response(directoriesResponse.subdirs);
         },
-        showNoResults: false,
-        cache: false
+        onSelect: function(event, term, item) {
+            let inputs = document.getElementsByClassName('path-search');
+
+            for (input of inputs) {
+                if (input.value === term) {
+                    input.oninput();
+                }
+            }
+        }
     });
 
     $('.class-card').form({

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -66,45 +66,44 @@ function setFormWarning(label, input, text) {
 
 
 function editNewProject() {
-    let newProjectNameInput = document.getElementById('newProjectName');
-    let newProjectNameLabel = document.getElementById('newProjectNameLabel');
-    let newProjectPathInput = document.getElementById('newProjectPath');
-    let newProjectPathLabel = document.getElementById('newProjectPathLabel');
-    let createProjectButton = document.getElementById('createProject');
+    let nameInput = document.getElementById('newProjectName');
+    let nameLabel = document.getElementById('newProjectNameLabel');
+    let pathInput = document.getElementById('newProjectPath');
+    let pathLabel = document.getElementById('newProjectPathLabel');
     let fullPathDiv = document.getElementById('fullPath');
+    let createProjectButton = document.getElementById('createProject');
 
-    let newProjectName = newProjectNameInput.value;
-    let newProjectPath = newProjectPathInput.value;
+    let name = nameInput.value;
+    let path = pathInput.value;
 
-    let directoriesResponse = browseDirectory(newProjectPath, newProjectName);
+    let directoriesResponse = browseDirectory(path, name);
     fullPathDiv.innerHTML = directoriesResponse.full_project_path;
 
     let disabled = false;
 
     // Check that project name is filled, unique and not yet present in directory
-    if (newProjectName === '') {
-        setFormWarning(newProjectNameLabel, newProjectNameInput, '');
+    if (name === '') {
+        setFormWarning(nameLabel, nameInput, '');
         disabled = true;
     } else if (!directoriesResponse.project_name_unique) {
-        setFormWarning(newProjectNameLabel, newProjectNameInput, 'This project name is already used');
+        setFormWarning(nameLabel, nameInput, 'This project name is already used');
         disabled = true;
     } else if (directoriesResponse.full_path_exists) {
-        setFormWarning(newProjectNameLabel, newProjectNameInput,
-                       'A directory with this name already exists in the chosen location');
+        setFormWarning(nameLabel, nameInput, 'A directory with this name already exists in the chosen location');
         disabled = true;
     } else {
-        setFormWarning(newProjectNameLabel, newProjectNameInput, '');
+        setFormWarning(nameLabel, nameInput, '');
     }
 
     // Check that project path is filled and exists
-    if (newProjectPath === '') {
-        setFormWarning(newProjectPathLabel, newProjectPathInput, '');
+    if (path === '') {
+        setFormWarning(pathLabel, pathInput, '');
         disabled = true;
     } else if (!directoriesResponse.path_exists) {
-        setFormWarning(newProjectPathLabel, newProjectPathInput, 'This path does not exist');
+        setFormWarning(pathLabel, pathInput, 'This path does not exist');
         disabled = true;
     } else {
-        setFormWarning(newProjectPathLabel, newProjectPathInput, '');
+        setFormWarning(pathLabel, pathInput, '');
     }
 
     createProjectButton.disabled = disabled;
@@ -112,29 +111,28 @@ function editNewProject() {
 
 
 function editImportProject() {
-    let importProjectPathInput = document.getElementById('importProjectPath');
-    let importProjectPathLabel = document.getElementById('importProjectPathLabel');
+    let pathInput = document.getElementById('importProjectPath');
+    let pathLabel = document.getElementById('importProjectPathLabel');
     let importProjectButton = document.getElementById('importProject');
 
-    let importProjectPath = importProjectPathInput.value;
+    let path = pathInput.value;
 
-    let directoriesResponse = browseDirectory(importProjectPath, '');
+    let directoriesResponse = browseDirectory(path, '');
 
     let disabled = false;
 
     // Check that project path is filled, unique and exists
-    if (importProjectPath === '') {
-        setFormWarning(importProjectPathLabel, importProjectPathInput, '');
+    if (path === '') {
+        setFormWarning(pathLabel, pathInput, '');
         disabled = true;
     } else if (!directoriesResponse.path_unique) {
-        setFormWarning(importProjectPathLabel, importProjectPathInput,
-                       'Another project is already registered in this location');
+        setFormWarning(pathLabel, pathInput, 'Another project is already registered in this location');
         disabled = true;
     } else if (!directoriesResponse.path_exists) {
-        setFormWarning(importProjectPathLabel, importProjectPathInput, 'This path does not exist');
+        setFormWarning(pathLabel, pathInput, 'This path does not exist');
         disabled = true;
     } else {
-        setFormWarning(importProjectPathLabel, importProjectPathInput, '');
+        setFormWarning(pathLabel, pathInput, '');
     }
 
     importProjectButton.disabled = disabled;

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -15,24 +15,22 @@ window.addEventListener(
 
 
 $(document).ready(function () {
-    new autoComplete({
-        selector: '.path-search',
-        minChars: 1,
-        cache: false,
-        source: function(term, response) {
-            let directoriesResponse = browseDirectory(term, '');
-            response(directoriesResponse.subdirs);
-        },
-        onSelect: function(event, term, item) {
-            let inputs = document.getElementsByClassName('path-search');
-
-            for (input of inputs) {
-                if (input.value === term) {
-                    input.oninput();
-                }
+    let pathSearchInputs = document.getElementsByClassName('path-search');
+    for (input of pathSearchInputs) {
+        const currentInput = input;
+        new autoComplete({
+            selector: input,
+            minChars: 1,
+            cache: false,
+            source: function(term, response) {
+                let directoriesResponse = browseDirectory(term, '');
+                response(directoriesResponse.subdirs);
+            },
+            onSelect: function(event, term, item) {
+                currentInput.oninput();
             }
-        }
-    });
+        });
+    }
 
     $('.class-card').form({
         fields: {
@@ -136,6 +134,35 @@ function editImportProject() {
     }
 
     importProjectButton.disabled = disabled;
+}
+
+
+function editUpdateProject(projectIdx) {
+    let pathInput = document.getElementById(`updateProjectPath${projectIdx}`);
+    let pathLabel = document.getElementById(`updateProjectLabel${projectIdx}`);
+    let updateProjectButton = document.getElementById(`updateProject${projectIdx}`);
+
+    let path = pathInput.value;
+
+    let directoriesResponse = browseDirectory(path, '');
+
+    let disabled = false;
+
+    // Check that project path is filled, unique and exists
+    if (path === '') {
+        setFormWarning(pathLabel, pathInput, '');
+        disabled = true;
+    } else if (!directoriesResponse.path_unique) {
+        setFormWarning(pathLabel, pathInput, 'Another project is already registered in this location');
+        disabled = true;
+    } else if (!directoriesResponse.path_exists) {
+        setFormWarning(pathLabel, pathInput, 'This path does not exist');
+        disabled = true;
+    } else {
+        setFormWarning(pathLabel, pathInput, '');
+    }
+
+    updateProjectButton.disabled = disabled;
 }
 
 

--- a/tools/sense_studio/templates/projects_overview.html
+++ b/tools/sense_studio/templates/projects_overview.html
@@ -73,7 +73,7 @@
         <span uk-icon="icon: file-edit"></span>
         Create New Project
     </button>
-    <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center">
+    <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center; mode:click">
         <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('setup_project') }}">
             <div class="uk-card-body">
                 <div>
@@ -89,11 +89,8 @@
                     <label class="uk-form-label uk-text-danger" id="newProjectPathLabel"></label>
                     <div class="uk-inline uk-width-1-1">
                         <span class="uk-form-icon" uk-icon="icon: folder"></span>
-                        <input class="uk-input" type="text" id="newProjectPath" name="path" placeholder="/path/to/project"
+                        <input class="uk-input path-search" type="text" id="newProjectPath" name="path" placeholder="/path/to/project"
                                autocomplete="off" oninput="editNewProject();">
-                        <div id="pathSuggestions" class="results">
-                            <!-- Filled automatically -->
-                        </div>
                     </div>
                 </div>
 
@@ -111,18 +108,15 @@
         <span uk-icon="icon: pull"></span>
         Import Existing Project
     </button>
-    <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center">
+    <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center; mode:click">
         <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('setup_project') }}">
             <div class="uk-card-body">
                 <div>
                     <label class="uk-form-label uk-text-danger" id="importProjectPathLabel"></label>
                     <div class="uk-inline uk-width-1-1">
                         <span class="uk-form-icon" uk-icon="icon: folder"></span>
-                        <input class="uk-input" type="text" id="importProjectPath" name="path" placeholder="/path/to/project"
+                        <input class="uk-input path-search" type="text" id="importProjectPath" name="path" placeholder="/path/to/project"
                                autocomplete="off" oninput="editImportProject();">
-                        <div id="importPathSuggestions" class="results">
-                            <!-- Filled automatically -->
-                        </div>
                     </div>
                 </div>
 

--- a/tools/sense_studio/templates/projects_overview.html
+++ b/tools/sense_studio/templates/projects_overview.html
@@ -9,7 +9,7 @@
     <div class="uk-child-width-1-2@s uk-child-width-1-3@m uk-flex-center" uk-grid>
         {% for name, project in projects.items() %}
         <div>
-            <form class="uk-card uk-card-default uk-card-hover" method="POST" action="{{ url_for('setup_project') }}">
+            <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('update_project') }}">
                 <input type="hidden" name="projectName" value="{{ name }}">
 
                 <div class="uk-card-header">
@@ -48,14 +48,17 @@
                             <span uk-icon="icon: warning"></span>
                             This path no longer exists.
                         </div>
-                        <div class="uk-inline uk-width-1-1">
-                            <span class="uk-form-icon" uk-icon="icon: folder"></span>
-                            <input class="uk-input" type="text" name="path" placeholder="/path/to/project" value="{{ project.path }}" autocomplete="off">
-                            <div id="pathSuggestions{{ loop.index }}" class="results">
-                                <!-- Filled automatically -->
+                        <div>
+                            <label class="uk-form-label uk-text-danger" id="updateProjectLabel{{ loop.index }}"></label>
+                            <div class="uk-inline uk-width-1-1">
+                                <span class="uk-form-icon" uk-icon="icon: folder"></span>
+                                <input class="uk-input path-search" type="text" id="updateProjectPath{{ loop.index }}"
+                                       name="path" placeholder="/path/to/project" value="{{ project.path }}" autocomplete="off"
+                                       oninput="editUpdateProject('{{ loop.index }}');">
                             </div>
                         </div>
-                        <button class="uk-button uk-button-default uk-margin-top uk-width-1-1" type="submit">
+                        <button class="uk-button uk-button-default uk-margin-top uk-width-1-1" type="submit"
+                                id="updateProject{{ loop.index }}" disabled>
                             <span uk-icon="icon: check"></span>
                             Save New Location
                         </button>
@@ -74,7 +77,7 @@
         Create New Project
     </button>
     <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center; mode:click">
-        <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('setup_project') }}">
+        <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('create_project') }}">
             <div class="uk-card-body">
                 <div>
                     <label class="uk-form-label uk-text-danger" id="newProjectNameLabel"></label>
@@ -109,7 +112,7 @@
         Import Existing Project
     </button>
     <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center; mode:click">
-        <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('setup_project') }}">
+        <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('import_project') }}">
             <div class="uk-card-body">
                 <div>
                     <label class="uk-form-label uk-text-danger" id="importProjectPathLabel"></label>

--- a/tools/sense_studio/templates/projects_overview.html
+++ b/tools/sense_studio/templates/projects_overview.html
@@ -6,10 +6,10 @@
 <div class="uk-container">
     <h1 class="uk-heading-medium uk-margin-large-top uk-margin-medium-bottom">Projects</h1>
 
-    <div class="uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid>
+    <div class="uk-child-width-1-2@s uk-child-width-1-3@m uk-flex-center" uk-grid>
         {% for name, project in projects.items() %}
         <div>
-            <form class="uk-card uk-card-default uk-card-hover update-project-card" method="POST" action="{{ url_for('setup_project') }}">
+            <form class="uk-card uk-card-default uk-card-hover" method="POST" action="{{ url_for('setup_project') }}">
                 <input type="hidden" name="projectName" value="{{ name }}">
 
                 <div class="uk-card-header">
@@ -64,28 +64,74 @@
             </form>
         </div>
         {% endfor %}
+    </div>
+</div>
 
-        <div>
-            <form class="uk-card uk-card-default uk-card-hover" id="newProjectCard" method="POST" action="{{ url_for('setup_project') }}">
-                <div class="uk-card-body">
+
+<div class="uk-width-1-1 uk-margin uk-text-center">
+    <button class="uk-button uk-button-default uk-margin-right" type="button">
+        <span uk-icon="icon: file-edit"></span>
+        Create New Project
+    </button>
+    <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center">
+        <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('setup_project') }}">
+            <div class="uk-card-body">
+                <div>
+                    <label class="uk-form-label uk-text-danger" id="newProjectNameLabel"></label>
                     <div class="uk-inline uk-width-1-1">
                         <span class="uk-form-icon" uk-icon="icon: home"></span>
-                        <input class="uk-input" type="text" name="projectName" placeholder="Project Name">
+                        <input class="uk-input" type="text" id="newProjectName" name="projectName" placeholder="Project Name"
+                               autocomplete="off" oninput="editNewProject();">
                     </div>
-                    <div class="uk-inline uk-width-1-1 uk-margin">
+                </div>
+
+                <div class="uk-margin">
+                    <label class="uk-form-label uk-text-danger" id="newProjectPathLabel"></label>
+                    <div class="uk-inline uk-width-1-1">
                         <span class="uk-form-icon" uk-icon="icon: folder"></span>
-                        <input class="uk-input" type="text" name="path" placeholder="/path/to/project" autocomplete="off">
+                        <input class="uk-input" type="text" id="newProjectPath" name="path" placeholder="/path/to/project"
+                               autocomplete="off" oninput="editNewProject();">
                         <div id="pathSuggestions" class="results">
                             <!-- Filled automatically -->
                         </div>
                     </div>
-                    <button class="uk-button uk-button-default uk-width-1-1" type="submit">
-                        <span uk-icon="icon: file-edit"></span>
-                        Create / Import
-                    </button>
                 </div>
-            </form>
-        </div>
+
+                <div class="uk-text-muted uk-text-center" id="fullPath"></div>
+
+                <button class="uk-button uk-button-default uk-width-1-1 uk-margin-top" type="submit" id="createProject" disabled>
+                    <span uk-icon="icon: file-edit"></span>
+                    Create
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <button class="uk-button uk-button-default" type="button">
+        <span uk-icon="icon: pull"></span>
+        Import Existing Project
+    </button>
+    <div class="uk-width-large uk-text-left" uk-drop="pos: bottom-center">
+        <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('setup_project') }}">
+            <div class="uk-card-body">
+                <div>
+                    <label class="uk-form-label uk-text-danger" id="importProjectPathLabel"></label>
+                    <div class="uk-inline uk-width-1-1">
+                        <span class="uk-form-icon" uk-icon="icon: folder"></span>
+                        <input class="uk-input" type="text" id="importProjectPath" name="path" placeholder="/path/to/project"
+                               autocomplete="off" oninput="editImportProject();">
+                        <div id="importPathSuggestions" class="results">
+                            <!-- Filled automatically -->
+                        </div>
+                    </div>
+                </div>
+
+                <button class="uk-button uk-button-default uk-width-1-1 uk-margin-top" type="submit" id="importProject" disabled>
+                    <span uk-icon="icon: pull"></span>
+                    Import
+                </button>
+            </div>
+        </form>
     </div>
 </div>
 {% endblock %}

--- a/tools/sense_studio/templates/skeleton.html
+++ b/tools/sense_studio/templates/skeleton.html
@@ -9,6 +9,9 @@
     <link rel="shortcut icon" href="{{ url_for('static', filename='sense_favicon.png') }}">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.6.17/dist/css/uikit.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.min.css"
+          integrity="sha512-5HGFIDMKYrcZJyxOxwiKGDXZWMwFYm1+V6Ax1UZGGglHQf3gM5liiUz2TqC4swdZD73ZRgyBJAtzjz/RzC10PA=="
+          crossorigin="anonymous" />
 
 	<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Merienda One">
 	<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Port Lligat Slab">
@@ -79,6 +82,9 @@
 
     <script src="https://cdn.jsdelivr.net/npm/uikit@3.6.17/dist/js/uikit.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/uikit@3.6.17/dist/js/uikit-icons.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/JavaScript-autoComplete/1.0.4/auto-complete.min.js"
+            integrity="sha512-LwZthDLbb+dritfG9jbFyY1ClYqlkF4I9foqo+783wcl6EPR+kE3uqb0OPsieHt4pFH4HVduwX6rTTDmCaC20g=="
+            crossorigin="anonymous"></script>
 
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>

--- a/tools/sense_studio/utils.py
+++ b/tools/sense_studio/utils.py
@@ -1,15 +1,8 @@
-import json
-import os
-
 from sense.engine import InferenceEngine
 from sense.loading import build_backbone_network
 from sense.loading import get_relevant_weights
 from sense.loading import ModelConfig
-
-MODULE_DIR = os.path.dirname(__file__)
-PROJECTS_OVERVIEW_CONFIG_FILE = os.path.join(MODULE_DIR, 'projects_config.json')
-
-PROJECT_CONFIG_FILE = 'project_config.json'
+from tools.sense_studio.project_utils import get_project_setting
 
 SUPPORTED_MODEL_CONFIGURATIONS = [
     ModelConfig('StridedInflatedEfficientNet', 'pro', []),
@@ -38,39 +31,6 @@ def is_image_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1] in ('png', 'jpg', 'jpeg', 'gif', 'bmp')
 
 
-def load_project_overview_config():
-    if os.path.isfile(PROJECTS_OVERVIEW_CONFIG_FILE):
-        with open(PROJECTS_OVERVIEW_CONFIG_FILE, 'r') as f:
-            projects = json.load(f)
-        return projects
-    else:
-        write_project_overview_config({})
-        return {}
-
-
-def write_project_overview_config(projects):
-    with open(PROJECTS_OVERVIEW_CONFIG_FILE, 'w') as f:
-        json.dump(projects, f, indent=2)
-
-
-def lookup_project_path(project_name):
-    projects = load_project_overview_config()
-    return projects[project_name]['path']
-
-
-def load_project_config(path):
-    config_path = os.path.join(path, PROJECT_CONFIG_FILE)
-    with open(config_path, 'r') as f:
-        config = json.load(f)
-    return config
-
-
-def write_project_config(path, config):
-    config_path = os.path.join(path, PROJECT_CONFIG_FILE)
-    with open(config_path, 'w') as f:
-        json.dump(config, f, indent=2)
-
-
 def get_class_name_and_tags(form_data):
     """
     Extract 'className', 'tag1' and 'tag2' from the given form data and make sure that the tags
@@ -85,19 +45,3 @@ def get_class_name_and_tags(form_data):
         tag2 = f'{tag2}_2'
 
     return class_name, tag1, tag2
-
-
-def get_project_setting(path, setting):
-    config = load_project_config(path)
-    return config.get(setting, False)
-
-
-def toggle_project_setting(path, setting):
-    config = load_project_config(path)
-    current_status = config.get(setting, False)
-
-    new_status = not current_status
-    config[setting] = new_status
-    write_project_config(path, config)
-
-    return new_status

--- a/tools/sense_studio/video_recording.py
+++ b/tools/sense_studio/video_recording.py
@@ -8,7 +8,7 @@ from flask import jsonify
 from flask import render_template
 from flask import request
 
-from tools.sense_studio import utils
+from tools.sense_studio import project_utils
 
 
 video_recording_bp = Blueprint('video_recording_bp', __name__)
@@ -22,7 +22,7 @@ def record_video(project, split, label):
     project = urllib.parse.unquote(project)
     split = urllib.parse.unquote(split)
     label = urllib.parse.unquote(label)
-    path = utils.lookup_project_path(project)
+    path = project_utils.lookup_project_path(project)
     return render_template('video_recording.html', project=project, split=split, label=label, path=path)
 
 
@@ -31,7 +31,7 @@ def save_video(project, split, label):
     project = urllib.parse.unquote(project)
     split = urllib.parse.unquote(split)
     label = urllib.parse.unquote(label)
-    path = utils.lookup_project_path(project)
+    path = project_utils.lookup_project_path(project)
 
     # Read given video to a file
     input_stream = request.files['video']


### PR DESCRIPTION
## Description

Before, it was confusing to have the same input fields and button for both creating new projects and importing existing ones. Now the two have been split and also redesigned to take less space per default.

Furthermore, you previously had to indicate the full path for the project to be created, while the project name was somehow unused. Now the project directory will automatically be created from the project name (with conversion to lower case and replacing spaces).

### Other Changes
- The new file `project_utils.py` has been created to bundle all project-related functions
- As part of switching to UIkit, the autocomplete mechanism for path search fields has been re-implemented by using [JavaScript-autoComplete](https://goodies.pixabay.com/javascript/auto-complete/demo.html)
- Form-checks have been added on the projects overview page