### PR TITLE
[Fix] Sort videos with "natural-sort" while annotating

### DIFF
--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -117,7 +117,7 @@ def annotate(project, split, label, idx):
     logreg_dir = directories.get_logreg_dir(path, model_config, label)
 
     videos = os.listdir(frames_dir)
-    videos.sort()
+    videos = natsorted(videos, alg=ns.IC)
 
     features = np.load(os.path.join(features_dir, f'{videos[idx]}.npy'))
     features = features.mean(axis=(2, 3))


### PR DESCRIPTION
This PR fixes the natural sorting of videos from video-list page to the annotation page.