### PR TITLE
Fix confusion matrix display

### DIFF
--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -299,7 +299,7 @@ def extract_features(path_in, model_config, net, num_layers_finetune, use_gpu, n
 
 
 def training_loops(net, train_loader, valid_loader, use_gpu, num_epochs, lr_schedule, label_names, path_out,
-                   temporal_annotation_training=False, log_fn=print):
+                   temporal_annotation_training=False, log_fn=print, confmat_event=None):
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.Adam(net.parameters(), lr=0.0001)
 
@@ -329,7 +329,7 @@ def training_loops(net, train_loader, valid_loader, use_gpu, num_epochs, lr_sche
             if valid_top1 > best_top1:
                 best_top1 = valid_top1
                 best_state_dict = net.state_dict().copy()
-                save_confusion_matrix(path_out, cnf_matrix, label_names)
+                save_confusion_matrix(path_out, cnf_matrix, label_names, confmat_event=confmat_event)
         else:
             if valid_loss < best_loss:
                 best_loss = valid_loss
@@ -418,7 +418,9 @@ def save_confusion_matrix(
         classes,
         normalize=False,
         title='Confusion matrix',
-        cmap=plt.cm.Blues):
+        cmap=plt.cm.Blues,
+        confmat_event=None,
+):
     """
     This function creates a matplotlib figure out of the provided confusion matrix and saves it
     to a file. The provided numpy array is also saved. Normalization can be applied by setting
@@ -454,3 +456,6 @@ def save_confusion_matrix(
     plt.close()
 
     np.save(os.path.join(path_out, 'confusion_matrix.npy'), confusion_matrix_array)
+
+    if confmat_event is not None:
+        confmat_event.set()

--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -304,8 +304,8 @@ def training_loops(net, train_loader, valid_loader, use_gpu, num_epochs, lr_sche
     optimizer = optim.Adam(net.parameters(), lr=0.0001)
 
     best_state_dict = None
-    best_top1 = 0.
-    best_loss = 9999
+    best_top1 = -1.
+    best_loss = float('inf')
 
     for epoch in range(0, num_epochs):  # loop over the dataset multiple times
         new_lr = lr_schedule.get(epoch)

--- a/tools/sense_studio/static/training.js
+++ b/tools/sense_studio/static/training.js
@@ -42,7 +42,12 @@ function startTraining(url) {
 
             buttonTrain.disabled = false;
             buttonCancelTrain.disabled = true;
-            confusionMatrix.innerHTML = `<img src=${message.img_path} alt='Confusion matrix' />`;
+
+            let reader = new FileReader();
+            reader.onload = function(e) {
+                confusionMatrix.src = `data:image/png;base64,${e.target.result}`;
+            };
+            reader.readAsBinaryString(new Blob([message.img]));
         }
     });
 
@@ -59,7 +64,7 @@ function startTraining(url) {
     buttonTrain.disabled = true;
     buttonCancelTrain.disabled = false;
     terminal.innerHTML = '';
-    confusionMatrix.innerHTML = '';
+    confusionMatrix.src = '';
 
     addTerminalMessage('Training started...');
 

--- a/tools/sense_studio/templates/training.html
+++ b/tools/sense_studio/templates/training.html
@@ -95,7 +95,7 @@
         </button>
     </form>
     <div id="terminal" class="uk-section uk-section-secondary uk-padding-small"></div>
-    <div id="confusionMatrix" class="uk-margin"></div>
+    <img id="confusionMatrix" class="uk-margin" src="" />
 </div>
 {% endblock %}
 

--- a/tools/sense_studio/training.py
+++ b/tools/sense_studio/training.py
@@ -119,5 +119,7 @@ def send_training_logs(msg):
         img_base64 = base64.b64encode(data)
         if img_base64:
             emit('success', {'status': 'Complete', 'img': img_base64})
+        else:
+            emit('failed', {'status': 'Failed'})
     else:
         emit('failed', {'status': 'Failed'})

--- a/tools/sense_studio/training.py
+++ b/tools/sense_studio/training.py
@@ -117,6 +117,7 @@ def send_training_logs(msg):
         with open(img_path, 'rb') as f:
             data = f.read()
         img_base64 = base64.b64encode(data)
-        emit('success', {'status': 'Complete', 'img': img_base64})
+        if img_base64:
+            emit('success', {'status': 'Complete', 'img': img_base64})
     else:
         emit('failed', {'status': 'Failed'})

--- a/tools/train_classifier.py
+++ b/tools/train_classifier.py
@@ -59,7 +59,8 @@ SUPPORTED_MODEL_CONFIGURATIONS = [
 
 
 def train_model(path_in, path_out, model_name, model_version, num_layers_to_finetune, epochs,
-                use_gpu=True, overwrite=True, temporal_training=None, resume=False, log_fn=print):
+                use_gpu=True, overwrite=True, temporal_training=None, resume=False, log_fn=print,
+                confmat_event=None):
     os.makedirs(path_out, exist_ok=True)
 
     # Check for existing files
@@ -201,7 +202,7 @@ def train_model(path_in, path_out, model_name, model_version, num_layers_to_fine
     # Train model
     best_model_state_dict = training_loops(net, train_loader, valid_loader, use_gpu, num_epochs, lr_schedule,
                                            label_names, path_out, temporal_annotation_training=temporal_training,
-                                           log_fn=log_fn)
+                                           log_fn=log_fn, confmat_event=confmat_event)
 
     # Save best model
     if isinstance(net, Pipe):


### PR DESCRIPTION
This PR fixes two error cases related to the display of the confusion matrix:

### 1. Caching
The browser was apparently caching the image of the confusion matrix (given through a URL), so if you ran a training multiple times in the same directory, you would always only see the first confusion matrix.
Now we directly send the binary image in the response from the server, so no URL can be cached.

### 2. Showing confusion matrix from previous run
If you ran another training in an existing checkpoint directory, but cancelled it before the first epoch (or ran a temporal training that doesn't produce a confusion matrix), the interface would still show the confusion matrix from the previous training run.
Now we use an `Event` to check, if a new confusion matrix has actually been produced in this training run.