### PR TITLE
[Fix] Train model button disabled if no models exist

### DIFF
--- a/tools/sense_studio/templates/training.html
+++ b/tools/sense_studio/templates/training.html
@@ -86,7 +86,8 @@
         </div>
 
         <button class="uk-button uk-button-primary uk-margin uk-margin-right" id="btnTrain" type="button" tabindex="0"
-                onclick="startTraining('{{ url_for('.start_training') }}');">
+                onclick="startTraining('{{ url_for('.start_training') }}');"
+                {% if not models %} disabled {% endif %}>
             Train model
         </button>
         <button class="uk-button uk-button-danger" id="btnCancelTrain" type="button" tabindex="1"


### PR DESCRIPTION
Description;

This PR will fix the issue of `Train Model` button staying active even if the models to choose from are not available on user's system.