### PR TITLE
[Fix] Disable train model button if no models exist

### DIFF
--- a/tools/sense_studio/templates/training.html
+++ b/tools/sense_studio/templates/training.html
@@ -32,10 +32,15 @@
                     </select>
                     {% if not models %}
                         <div uk-dropdown>
-                            Weights file missing, <br/>
+                            <p>
+                                Pre-trained backbone model weights couldn't be found.
+                            </p>
                             To download, please go to
-                            <a href="https://20bn.com/licensing/sdk/evaluation">https://20bn.com/licensing/sdk/evaluation</a>
+                            <a target="_blank" rel="noopener noreferrer" href="https://20bn.com/licensing/sdk/evaluation">
+                                https://20bn.com/licensing/sdk/evaluation
+                            </a>
                             and follow the instructions.
+                            Then, extract the <code>backbone</code> folder into <code>sense/resources</code>.
                         </div>
                     {% endif %}
                 </div>

--- a/tools/sense_studio/templates/training.html
+++ b/tools/sense_studio/templates/training.html
@@ -18,10 +18,10 @@
         <input type="hidden" id="path" name="path" value="{{ path }}">
 
         <div class="uk-child-width-1-2@s uk-grid-small" uk-grid>
-            <div>
+            <div class="uk-inline">
                 <label class="uk-form-label" for="modelName">Backbone Model</label>
                 <div class="uk-form-controls">
-                    <select class="uk-select" id="modelName">
+                    <select class="uk-select {{ 'uk-form-danger' if not models }}" id="modelName">
                         {% if models %}
                             {% for model in models %}
                                 <option>{{ model }}</option>
@@ -30,6 +30,14 @@
                             <option value="">No models available</option>
                         {% endif %}
                     </select>
+                    {% if not models %}
+                        <div uk-dropdown>
+                            Weights file missing, <br/>
+                            To download, please go to
+                            <a href="https://20bn.com/licensing/sdk/evaluation">https://20bn.com/licensing/sdk/evaluation</a>
+                            and follow the instructions.
+                        </div>
+                    {% endif %}
                 </div>
             </div>
 


### PR DESCRIPTION
Description;

This PR will fix the issue of Train Model button staying active even if the models to choose from are not available on user's system.

It will also show a hint to the user about where to get the models.