### PR TITLE
Safe path handling in the full path display

### DIFF
--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -90,8 +90,9 @@ def browse_directory():
     """
     Browse the local file system starting at the given path and provide the following information:
     - project_name_unique: If the given project name is not yet registered in the projects list
-    - full_project_path: Full path constructed from base path and project name
-    - full_path_exists: If the full path exists
+    - project_path_prefix: The given path with a final separator, e.g. /data/
+    - project_dir: Name of the project directory generated from the project name
+    - project_dir_exists: If the project directory already exists in the given path
     - path_exists: If the given path exists
     - path_unique: If the given path is not yet registered for another project
     - subdirs: The list of sub-directories at the given path
@@ -101,14 +102,16 @@ def browse_directory():
     project = data['project']
 
     subdirs = [d for d in glob.glob(f'{path}*') if os.path.isdir(d)] if os.path.isabs(path) else []
-    full_path = os.path.join(path, project_utils.get_folder_name_for_project(project))
+    project_dir = project_utils.get_folder_name_for_project(project)
+    full_path = os.path.join(path, project_dir)
 
     projects = project_utils.load_project_overview_config()
 
     return jsonify(
         project_name_unique=project not in projects,
-        full_project_path=full_path,
-        full_path_exists=os.path.exists(full_path),
+        project_path_prefix=os.path.join(path, ''),  # Append a separator
+        project_dir=project_dir,
+        project_dir_exists=os.path.exists(full_path),
         path_exists=os.path.exists(path),
         path_unique=path not in [p['path'] for p in projects.values()],
         subdirs=subdirs,

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -57,10 +57,12 @@ async function editNewProject() {
 
     let directoriesResponse = await browseDirectory(path, name);
 
-    let disabled = false;
+    // Show project path and highlight the name of the folder that will be created
+    pathPrefix = directoriesResponse.project_path_prefix
+    projectDir = directoriesResponse.project_dir
+    fullPathDiv.innerHTML = `<p>${pathPrefix}<span class='uk-text-primary uk-text-bolder'>${projectDir}</span></p>`;
 
-    // Display project name with a different style
-    fullPathDiv.innerHTML = `<p>${path}/<span class='uk-text-primary uk-text-bolder'>${name}</span></p>`;
+    let disabled = false;
 
     // Check that project name is filled, unique and not yet present in directory
     if (name === '') {
@@ -69,7 +71,7 @@ async function editNewProject() {
     } else if (!directoriesResponse.project_name_unique) {
         setFormWarning(nameLabel, nameInput, 'This project name is already used');
         disabled = true;
-    } else if (directoriesResponse.full_path_exists) {
+    } else if (directoriesResponse.project_dir_exists) {
         setFormWarning(nameLabel, nameInput, 'A directory with this name already exists in the chosen location');
         disabled = true;
     } else {

--- a/tools/sense_studio/templates/projects_overview.html
+++ b/tools/sense_studio/templates/projects_overview.html
@@ -18,6 +18,7 @@
                 <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST" action="{{ url_for('create_project') }}">
                     <div class="uk-card-body">
                         <span class="uk-text-muted uk-text-center" id="fullPath"></span>
+
                         <div>
                             <label class="uk-form-label uk-text-danger" id="newProjectNameLabel"></label>
                             <div class="uk-inline uk-width-1-1">
@@ -36,7 +37,7 @@
                             </div>
                         </div>
 
-                        <button class="uk-button uk-button-default uk-width-1-1 uk-margin-top" type="submit" id="createProject" disabled>
+                        <button class="uk-button uk-button-default uk-width-1-1" type="submit" id="createProject" disabled>
                             <span uk-icon="icon: file-edit"></span>
                             Create
                         </button>


### PR DESCRIPTION
Thanks for the design update in #156!

There were a few small issues with the previous solution though:
- The project name was shown as the project directory, but actually the name is transformed on the backend before the directory is created (e.g. to avoid spaces in the folder name)
- The shown path would be incorrect on Windows, because it would always append a `/`
- When clearing both input fields, the label would still show a single '/'

Now the proper path handling is done on the backend and all necessary information is transferred to the JS side.