### PR TITLE
Resample testing videos

### DIFF
--- a/sense/camera.py
+++ b/sense/camera.py
@@ -8,6 +8,25 @@ from typing import Optional
 from typing import Tuple
 
 
+def uniform_frame_sample(video, sample_rate):
+    """
+    Uniformly sample video frames according to the provided sample_rate.
+    """
+    available_frames = video.shape[0]
+    required_frames = np.round(sample_rate * available_frames).astype(np.int32)
+
+    # Get evenly spaced indices. When upsampling, include both endpoints.
+    new_indices = np.linspace(0, available_frames - 1, num=required_frames, endpoint=sample_rate >= 1.)
+
+    # Center the indices
+    offset = ((available_frames - 1) - new_indices[-1]) / 2
+    new_indices += offset
+
+    # Round to closest integers
+    new_indices = new_indices.round().astype(np.int32)
+    return video[new_indices]
+
+
 class VideoSource:
     """
     VideoSource captures frames from a camera or a video source file.

--- a/sense/camera.py
+++ b/sense/camera.py
@@ -36,7 +36,8 @@ class VideoSource:
                  filename: str = None,
                  size: Tuple[int, int] = None,
                  camera_id: int = 0,
-                 preserve_aspect_ratio: bool = True):
+                 preserve_aspect_ratio: bool = True,
+                 target_fps: Optional[int] = None):
         """
         :param filename:
             Path to a video file.
@@ -46,23 +47,57 @@ class VideoSource:
             Device index for the camera.
         :param preserve_aspect_ratio:
             Whether to preserve the aspect ratio of the video frames.
+        :param target_fps:
+            Framerate that the video should be sampled to. If None is given, framerate of the video is left unchanged.
+            Only relevant if the video is read from a file.
         """
         self.size = size
         self.preserve_aspect_ratio = preserve_aspect_ratio
+
+        self._frames = None
+        self._frame_idx = 0
+
         if filename:
             self._cam = cv2.VideoCapture(filename)
+
+            if target_fps is not None:
+                self._frames = self._read_and_resample_frames(target_fps)
         else:
             self._cam = cv2.VideoCapture(camera_id)
             self._cam.set(3, 480)  # Set frame width to 480
             self._cam.set(4, 640)  # Set frame height to 640
+
+    def _read_and_resample_frames(self, target_fps):
+        video_fps = self._cam.get(cv2.CAP_PROP_FPS)
+
+        video = []
+        ret, frame = self._cam.read()
+        while ret:
+            video.append(frame)
+            ret, frame = self._cam.read()
+
+        return uniform_frame_sample(np.array(video), target_fps / video_fps)
+
+    def _get_frame(self):
+        if self._frames is not None:
+            if self._frame_idx < len(self._frames):
+                frame = self._frames[self._frame_idx]
+                self._frame_idx += 1
+                return frame
+        else:
+            ret, frame = self._cam.read()
+            if ret:
+                return frame
+
+        return None
 
     def get_image(self) -> Optional[Tuple[np.ndarray, np.ndarray]]:
         """
         Capture image from video stream frame-by-frame.
         The captured image and a scaled copy of the image are returned.
         """
-        ret, img = self._cam.read()
-        if ret:
+        img = self._get_frame()
+        if img is not None:
             img_copy = img.copy()
             if self.preserve_aspect_ratio:
                 img_copy = self.pad_to_square(img)
@@ -80,10 +115,6 @@ class VideoSource:
         pad_left = int((square_size - img.shape[1]) / 2)
         pad_right = square_size - img.shape[1] - pad_left
         return cv2.copyMakeBorder(img, pad_top, pad_bottom, pad_left, pad_right, cv2.BORDER_CONSTANT)
-
-    def get_fps(self) -> float:
-        """Return the frame rate of the video source."""
-        return self._cam.get(cv2.CAP_PROP_FPS)
 
 
 class VideoStream(Thread):

--- a/sense/controller.py
+++ b/sense/controller.py
@@ -52,7 +52,8 @@ class Controller:
         video_source = VideoSource(
             camera_id=camera_id,
             size=self.inference_engine.expected_frame_size,
-            filename=path_in
+            filename=path_in,
+            target_fps=self.inference_engine.fps,
         )
         self.video_stream = VideoStream(video_source, self.inference_engine.fps)
 

--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -147,19 +147,6 @@ def generate_data_loader(project_config, features_dir, tags_dir, label_names, la
         return None
 
 
-def uniform_frame_sample(video, sample_rate):
-    """
-    Uniformly sample video frames according to the provided sample_rate.
-    """
-    depth = video.shape[0]
-    if sample_rate < 1.:
-        indices = np.arange(0, depth, 1. / sample_rate)
-        offset = int((depth - indices[-1]) / 2)
-        sampled_frames = (indices + offset).astype(np.int32)
-        return video[sampled_frames]
-    return video
-
-
 def extract_frames(video_path, inference_engine, path_frames=None, return_frames=True):
     save_frames = path_frames is not None and not os.path.exists(path_frames)
 

--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -155,8 +155,9 @@ def extract_frames(video_path, inference_engine, path_frames=None, return_frames
         return None
 
     # Read frames from video
-    video_source = camera.VideoSource(size=inference_engine.expected_frame_size, filename=video_path)
-    video_fps = video_source.get_fps()
+    video_source = camera.VideoSource(size=inference_engine.expected_frame_size,
+                                      filename=video_path,
+                                      target_fps=inference_engine.fps)
     frames = []
 
     while True:
@@ -167,7 +168,7 @@ def extract_frames(video_path, inference_engine, path_frames=None, return_frames
             image, image_rescaled = images
             frames.append(image_rescaled)
 
-    frames = uniform_frame_sample(np.array(frames), inference_engine.fps / video_fps)
+    frames = np.array(frames)
 
     # Save frames if a path was provided
     if save_frames:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,55 @@
+import os
+import unittest
+from unittest.mock import patch
+import numpy as np
+
+from sense.camera import uniform_frame_sample
+from sense.camera import VideoSource
+
+
+class TestUniformFrameSample(unittest.TestCase):
+
+    VIDEO = np.array([1, 2, 3, 4, 5, 6])
+
+    def test_upsampling(self):
+        upsampled_video = uniform_frame_sample(self.VIDEO, 1.5)
+        assert np.array_equal(upsampled_video, [1, 2, 2, 3, 3, 4, 5, 5, 6])
+
+    def test_downsampling(self):
+        downsampled_video = uniform_frame_sample(self.VIDEO, 0.5)
+        assert np.array_equal(downsampled_video, [2, 3, 5])
+
+    def test_no_change(self):
+        same_video = uniform_frame_sample(self.VIDEO, 1.0)
+        assert np.array_equal(same_video, self.VIDEO)
+
+
+class TestVideoSource(unittest.TestCase):
+
+    VIDEO_FILE = os.path.join(os.path.dirname(__file__), 'resources', 'test_video.mp4')
+
+    def test_from_file(self):
+        video_source = VideoSource(filename=self.VIDEO_FILE)
+        assert video_source._frames is None
+        assert video_source.get_image() is not None
+
+    def test_from_file_change_fps(self):
+        video_source = VideoSource(filename=self.VIDEO_FILE, target_fps=5)
+        assert video_source._frames is not None  # Frames should be pre-computed and resampled
+        assert video_source.get_image() is not None
+
+    def test_from_camera(self):
+        class MockVideoSource:
+            def __init__(self, *args):
+                pass
+
+            def set(self, *args):
+                pass
+
+            def read(self):
+                return True, np.zeros((2, 3))
+
+        with patch('cv2.VideoCapture', MockVideoSource):
+            video_source = VideoSource(camera_id=0)
+        assert video_source._frames is None
+        assert video_source.get_image() is not None


### PR DESCRIPTION
Make sure that videos during testing are also presented to the model at the correct frame rate. Currently, they would be read at their original frame rate while assuming it to be the model frame rate, making them look slower or faster.

- The `uniform_frame_sample` method has been extended to also handle the case of upsampling
- A `VideoSource` can now have a `target_fps` defined. If this is given, the video is immediately read and resampled on initialization.
- This same mechanism is now used in both training and testing
- Unit tests for the new behavior have been added

This is a different approach to #155 