### PR TITLE
Backwards compatibility and missing updates for project tags

### DIFF
--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -115,7 +115,7 @@ def generate_data_loader(project_config, features_dir, tags_dir, label_names, la
         labels_string += [label] * len(feature_temp)
 
     if project_config:
-        tag_mapping = project_config['project_tags'].copy()
+        tag_mapping = project_config['tags'].copy()
         tag_mapping[0] = 'background'
 
     # Check if temporal annotations exist for each video

--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -115,7 +115,8 @@ def generate_data_loader(project_config, features_dir, tags_dir, label_names, la
         labels_string += [label] * len(feature_temp)
 
     if project_config:
-        tag_mapping = project_config['project_tags']
+        tag_mapping = project_config['project_tags'].copy()
+        tag_mapping[0] = 'background'
 
     # Check if temporal annotations exist for each video
     for label, feature in zip(labels_string, features):

--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -115,7 +115,7 @@ def generate_data_loader(project_config, features_dir, tags_dir, label_names, la
         labels_string += [label] * len(feature_temp)
 
     if project_config:
-        tag_mapping = {tag_index: tag_name for tag_name, tag_index in project_config['project_tags'].items()}
+        tag_mapping = project_config['project_tags']
 
     # Check if temporal annotations exist for each video
     for label, feature in zip(labels_string, features):

--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -126,10 +126,18 @@ def generate_data_loader(project_config, features_dir, tags_dir, label_names, la
                 tag1 = f'{label}_tag1'
                 tag2 = f'{label}_tag2'
                 tag_mapping = {0: 'background', 1: tag1, 2: tag2}
+                class_tags = {0, 1, 2}
+            else:
+                class_tags = set(project_config['classes'][label])
 
             with open(temporal_annotation_file, 'r') as f:
                 annotations = json.load(f)['time_annotation']
-            annotations = np.array([label2int_temporal_annotation[tag_mapping[y]] for y in annotations])
+
+            # Translate tags to class names and then to integer labels for this training run
+            # Reset tags that have been removed from a class to 'background'
+            annotations = np.array([label2int_temporal_annotation[tag_mapping[y]] if y in class_tags
+                                    else label2int_temporal_annotation['background']
+                                    for y in annotations])
             temporal_annotation.append(annotations)
         else:
             temporal_annotation.append(None)

--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -104,7 +104,6 @@ def generate_data_loader(project_config, features_dir, tags_dir, label_names, la
     # Find pre-computed features and derive corresponding labels
     labels_string = []
     temporal_annotation = []
-    project_tags = {}
 
     # Use all pre-computed features
     features = []
@@ -116,22 +115,21 @@ def generate_data_loader(project_config, features_dir, tags_dir, label_names, la
         labels_string += [label] * len(feature_temp)
 
     if project_config:
-        project_tags = {tag_index: tag_name for tag_name, tag_index in project_config['project_tags'].items()}
+        tag_mapping = {tag_index: tag_name for tag_name, tag_index in project_config['project_tags'].items()}
 
     # Check if temporal annotations exist for each video
     for label, feature in zip(labels_string, features):
         temporal_annotation_file = feature.replace(features_dir, tags_dir).replace(".npy", ".json")
         if os.path.isfile(temporal_annotation_file) and temporal_annotation_only:
-            if project_config:
-                class_mapping = {tag_index: project_tags[tag_index] for tag_index in project_config['classes'][label]}
-            else:
+            if not project_config:
                 tag1 = f'{label}_tag1'
                 tag2 = f'{label}_tag2'
-                class_mapping = {0: 'background', 1: tag1, 2: tag2}
+                tag_mapping = {0: 'background', 1: tag1, 2: tag2}
 
-            annotation = json.load(open(temporal_annotation_file))["time_annotation"]
-            annotation = np.array([label2int_temporal_annotation[class_mapping[y]] for y in annotation])
-            temporal_annotation.append(annotation)
+            with open(temporal_annotation_file, 'r') as f:
+                annotations = json.load(f)['time_annotation']
+            annotations = np.array([label2int_temporal_annotation[tag_mapping[y]] for y in annotations])
+            temporal_annotation.append(annotations)
         else:
             temporal_annotation.append(None)
 

--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -110,6 +110,9 @@ def annotate(project, split, label, idx):
             features = np.load(features_path).mean(axis=(2, 3))
             classes = list(logreg.predict(features))
 
+            # Reset tags that have been removed from the class to 'background'
+            classes = [tag_idx if tag_idx in class_tags else 0 for tag_idx in classes]
+
     # Natural sort images, so that they are sorted by number
     images = natsorted(images, alg=ns.IC)
     # Extract image file name (without full path) and include class label
@@ -121,6 +124,9 @@ def annotate(project, split, label, idx):
         with open(annotations_file, 'r') as f:
             data = json.load(f)
             annotations = data['time_annotation']
+
+            # Reset tags that have been removed from the class to 'background'
+            annotations = [tag_idx if tag_idx in class_tags else 0 for tag_idx in annotations]
     else:
         # Use "background" label for all frames per default
         annotations = [0] * len(images)

--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -79,8 +79,8 @@ def annotate(project, split, label, idx):
     split = urllib.parse.unquote(split)
 
     config = project_utils.load_project_config(path)
-    project_tags = config['project_tags'].copy()
-    project_tags[0] = 'background'
+    tags = config['tags'].copy()
+    tags[0] = 'background'
 
     class_tags = config['classes'][label].copy()
     class_tags.append(0)  # Always add 'background'
@@ -131,14 +131,10 @@ def annotate(project, split, label, idx):
         # Use "background" label for all frames per default
         annotations = [0] * len(images)
 
-    # Read tags from config
-    config = project_utils.load_project_config(path)
-    tags = config['classes'][label]
-
     return render_template('frame_annotation.html', images=images, annotations=annotations, idx=idx, fps=16,
                            n_images=len(images), video_name=videos[idx], project_config=config,
-                           split=split, label=label, path=path, tags=tags, project=project, n_videos=len(videos),
-                           project_tags=project_tags, class_tags=class_tags)
+                           split=split, label=label, path=path, project=project, n_videos=len(videos),
+                           tags=tags, class_tags=class_tags)
 
 
 @annotation_bp.route('/submit-annotation', methods=['POST'])

--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -5,7 +5,6 @@ import os
 import urllib
 
 from flask import Blueprint
-from flask import jsonify
 from flask import redirect
 from flask import render_template
 from flask import request
@@ -15,7 +14,6 @@ from joblib import load
 from natsort import natsorted
 from natsort import ns
 
-from sense import SPLITS
 from sense.finetuning import compute_frames_and_features
 from tools import directories
 from tools.sense_studio import project_utils
@@ -81,7 +79,7 @@ def annotate(project, split, label, idx):
     split = urllib.parse.unquote(split)
 
     config = project_utils.load_project_config(path)
-    project_tags = {tag_index: tag_name for tag_name, tag_index in config['project_tags'].items()}
+    project_tags = config['project_tags']
     class_tags = config['classes'][label]
     class_tags.sort()
 

--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -79,8 +79,11 @@ def annotate(project, split, label, idx):
     split = urllib.parse.unquote(split)
 
     config = project_utils.load_project_config(path)
-    project_tags = config['project_tags']
-    class_tags = config['classes'][label]
+    project_tags = config['project_tags'].copy()
+    project_tags[0] = 'background'
+
+    class_tags = config['classes'][label].copy()
+    class_tags.append(0)  # Always add 'background'
     class_tags.sort()
 
     _, model_config = utils.load_feature_extractor(path)

--- a/tools/sense_studio/project_tags.py
+++ b/tools/sense_studio/project_tags.py
@@ -24,6 +24,7 @@ def create_tag_in_project_tags(project):
         max_tag_index = max(project_tags.keys())
         project_tags[max_tag_index + 1] = tag_name
     else:
+        # 0 is reserved for 'background'
         project_tags[1] = tag_name
 
     project_utils.write_project_config(path, config)
@@ -51,7 +52,7 @@ def remove_tag_from_project_tags(project, tag_idx):
 
 @project_tags_bp.route('/edit-project-tag/<string:project>/<int:tag_idx>', methods=['POST'])
 def edit_tag_in_project_tags(project, tag_idx):
-    data = request.json
+    data = request.form
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
     config = project_utils.load_project_config(path)
@@ -62,4 +63,4 @@ def edit_tag_in_project_tags(project, tag_idx):
     project_tags[tag_idx] = new_tag_name
 
     project_utils.write_project_config(path, config)
-    return jsonify(success=True)
+    return redirect(url_for('project_details', project=project))

--- a/tools/sense_studio/project_tags.py
+++ b/tools/sense_studio/project_tags.py
@@ -20,12 +20,9 @@ def create_tag_in_project_tags(project):
     tag_name = data['newTagName']
 
     project_tags = config['project_tags']
-    if project_tags:
-        max_tag_index = max(project_tags.keys())
-        project_tags[max_tag_index + 1] = tag_name
-    else:
-        # 0 is reserved for 'background'
-        project_tags[1] = tag_name
+    new_tag_index = config['max_tag_index'] + 1
+    project_tags[new_tag_index] = tag_name
+    config['max_tag_index'] = new_tag_index
 
     project_utils.write_project_config(path, config)
     return redirect(url_for('project_details', project=project))

--- a/tools/sense_studio/project_tags.py
+++ b/tools/sense_studio/project_tags.py
@@ -1,18 +1,17 @@
 import urllib
 
 from flask import Blueprint
-from flask import jsonify
 from flask import redirect
 from flask import request
 from flask import url_for
 
 from tools.sense_studio import project_utils
 
-project_tags_bp = Blueprint('project_tags_bp', __name__)
+tags_bp = Blueprint('tags_bp', __name__)
 
 
-@project_tags_bp.route('/create-project-tag/<string:project>', methods=['POST'])
-def create_tag_in_project_tags(project):
+@tags_bp.route('/create-project-tag/<string:project>', methods=['POST'])
+def create_tag(project):
     data = request.form
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
@@ -28,8 +27,8 @@ def create_tag_in_project_tags(project):
     return redirect(url_for('project_details', project=project))
 
 
-@project_tags_bp.route('/remove-project-tag/<string:project>/<int:tag_idx>')
-def remove_tag_from_project_tags(project, tag_idx):
+@tags_bp.route('/remove-project-tag/<string:project>/<int:tag_idx>')
+def remove_tag(project, tag_idx):
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
     config = project_utils.load_project_config(path)
@@ -47,8 +46,8 @@ def remove_tag_from_project_tags(project, tag_idx):
     return redirect(url_for('project_details', project=project))
 
 
-@project_tags_bp.route('/edit-project-tag/<string:project>/<int:tag_idx>', methods=['POST'])
-def edit_tag_in_project_tags(project, tag_idx):
+@tags_bp.route('/edit-project-tag/<string:project>/<int:tag_idx>', methods=['POST'])
+def edit_tag(project, tag_idx):
     data = request.form
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)

--- a/tools/sense_studio/project_tags.py
+++ b/tools/sense_studio/project_tags.py
@@ -28,15 +28,13 @@ def create_tag_in_project_tags(project):
 
     config['project_tags'] = project_tags
     project_utils.write_project_config(path, config)
-    return redirect(url_for("project_details", project=project))
+    return redirect(url_for('project_details', project=project))
 
 
-@project_tags_bp.route('/remove-project-tag/<string:project>', methods=['POST'])
-def remove_tag_from_project_tags(project):
-    data = request.json
+@project_tags_bp.route('/remove-project-tag/<string:project>/<int:remove_tag_idx>')
+def remove_tag_from_project_tags(project, remove_tag_idx):
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
-    remove_tag_idx = int(data['tagIdx'])
     config = project_utils.load_project_config(path)
     project_tags = config['project_tags']
 
@@ -51,18 +49,17 @@ def remove_tag_from_project_tags(project):
             config['classes'][class_label] = tags
 
     project_utils.write_project_config(path, config)
-    return jsonify(success=True)
+    return redirect(url_for('project_details', project=project))
 
 
-@project_tags_bp.route('/edit-project-tag/<string:project>', methods=['POST'])
-def edit_tag_in_project_tags(project):
+@project_tags_bp.route('/edit-project-tag/<string:project>/<int:tag_idx>', methods=['POST'])
+def edit_tag_in_project_tags(project, tag_idx):
     data = request.json
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
-    tag_idx = data['tagIdx']
-    new_tag_name = data['newTagName']
     config = project_utils.load_project_config(path)
     project_tags = config['project_tags']
+    new_tag_name = data['newTagName']
 
     updated_tags = {}
     for tag_name, tag_index in project_tags.items():

--- a/tools/sense_studio/project_tags.py
+++ b/tools/sense_studio/project_tags.py
@@ -19,34 +19,31 @@ def create_tag_in_project_tags(project):
     config = project_utils.load_project_config(path)
     tag_name = data['newTagName']
 
-    project_tags = config.get('project_tags', {})
+    project_tags = config['project_tags']
     if project_tags:
-        max_tag_index = max(project_tags.values())
-        project_tags[tag_name] = max_tag_index + 1
+        max_tag_index = max(project_tags.keys())
+        project_tags[max_tag_index + 1] = tag_name
     else:
-        project_tags[tag_name] = 1
+        project_tags[1] = tag_name
 
-    config['project_tags'] = project_tags
     project_utils.write_project_config(path, config)
     return redirect(url_for('project_details', project=project))
 
 
-@project_tags_bp.route('/remove-project-tag/<string:project>/<int:remove_tag_idx>')
-def remove_tag_from_project_tags(project, remove_tag_idx):
+@project_tags_bp.route('/remove-project-tag/<string:project>/<int:tag_idx>')
+def remove_tag_from_project_tags(project, tag_idx):
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
     config = project_utils.load_project_config(path)
     project_tags = config['project_tags']
 
     # Remove tag from the project tags list
-    project_tags = {tag_name: tag_index for tag_name, tag_index in project_tags.items() if tag_index != remove_tag_idx}
-    config['project_tags'] = project_tags
+    del project_tags[tag_idx]
 
     # Remove tag from the classes
     for class_label, tags in config['classes'].items():
-        if remove_tag_idx in tags:
-            tags.remove(remove_tag_idx)
-            config['classes'][class_label] = tags
+        if tag_idx in tags:
+            tags.remove(tag_idx)
 
     project_utils.write_project_config(path, config)
     return redirect(url_for('project_details', project=project))
@@ -61,13 +58,8 @@ def edit_tag_in_project_tags(project, tag_idx):
     project_tags = config['project_tags']
     new_tag_name = data['newTagName']
 
-    updated_tags = {}
-    for tag_name, tag_index in project_tags.items():
-        if tag_index == int(tag_idx):
-            updated_tags[new_tag_name] = tag_index
-        else:
-            updated_tags[tag_name] = tag_index
+    # Update tag name
+    project_tags[tag_idx] = new_tag_name
 
-    config['project_tags'] = updated_tags
     project_utils.write_project_config(path, config)
     return jsonify(success=True)

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -63,6 +63,7 @@ def _backwards_compatibility_update(path, config):
         # Assign project-wide unique indices to tags (0 is reserved for 'background')
         project_tags = {idx + 1: tag_name for idx, tag_name in enumerate(project_tags_list)}
         config['project_tags'] = project_tags
+        config['max_tag_index'] = len(project_tags_list)
 
         # Setup class dictionary with tag indices
         inverse_project_tags = {tag_name: tag_idx for tag_idx, tag_name in project_tags.items()}
@@ -134,6 +135,7 @@ def setup_new_project(project_name, path, config=None):
             'name': project_name,
             'date_created': datetime.date.today().isoformat(),
             'project_tags': {},
+            'max_tag_index': 0,
             'classes': {},
             'use_gpu': False,
             'temporal': False,

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -60,13 +60,13 @@ def _backwards_compatibility_update(path, config):
         for class_name, class_tags in old_classes.items():
             project_tags_list.extend(class_tags)
 
-        # Assign project-wide unique indices to tags
+        # Assign project-wide unique indices to tags (0 is reserved for 'background')
         project_tags = {idx + 1: tag_name for idx, tag_name in enumerate(project_tags_list)}
-        project_tags[0] = 'background'
         config['project_tags'] = project_tags
 
         # Setup class dictionary with tag indices
         inverse_project_tags = {tag_name: tag_idx for tag_idx, tag_name in project_tags.items()}
+        inverse_project_tags['background'] = 0
         config['classes'] = {
             class_name: [inverse_project_tags[tag_name] for tag_name in class_tags]
             for class_name, class_tags in old_classes.items()
@@ -133,9 +133,7 @@ def setup_new_project(project_name, path, config=None):
         config = {
             'name': project_name,
             'date_created': datetime.date.today().isoformat(),
-            'project_tags': {
-                0: 'background',
-            },
+            'project_tags': {},
             'classes': {},
             'use_gpu': False,
             'temporal': False,

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -61,7 +61,7 @@ def _backwards_compatibility_update(path, config):
             tags_list.extend(class_tags)
 
         # Assign project-wide unique indices to tags (0 is reserved for 'background')
-        tags = {idx + 1: tag_name for idx, tag_name in enumerate(tags_list)}
+        tags = {idx + 1: tag_name for idx, tag_name in enumerate(sorted(tags_list))}
         config['tags'] = tags
         config['max_tag_index'] = len(tags_list)
 

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -53,23 +53,23 @@ def _backwards_compatibility_update(path, config):
         }
         updated = True
 
-    if 'project_tags' not in config:
+    if 'tags' not in config:
         # Collect class-wise tags
         old_classes = config['classes']
-        project_tags_list = []
+        tags_list = []
         for class_name, class_tags in old_classes.items():
-            project_tags_list.extend(class_tags)
+            tags_list.extend(class_tags)
 
         # Assign project-wide unique indices to tags (0 is reserved for 'background')
-        project_tags = {idx + 1: tag_name for idx, tag_name in enumerate(project_tags_list)}
-        config['project_tags'] = project_tags
-        config['max_tag_index'] = len(project_tags_list)
+        tags = {idx + 1: tag_name for idx, tag_name in enumerate(tags_list)}
+        config['tags'] = tags
+        config['max_tag_index'] = len(tags_list)
 
         # Setup class dictionary with tag indices
-        inverse_project_tags = {tag_name: tag_idx for tag_idx, tag_name in project_tags.items()}
-        inverse_project_tags['background'] = 0
+        inverse_tags = {tag_name: tag_idx for tag_idx, tag_name in tags.items()}
+        inverse_tags['background'] = 0
         config['classes'] = {
-            class_name: [inverse_project_tags[tag_name] for tag_name in class_tags]
+            class_name: [inverse_tags[tag_name] for tag_name in class_tags]
             for class_name, class_tags in old_classes.items()
         }
 
@@ -88,8 +88,7 @@ def _backwards_compatibility_update(path, config):
                         annotation_data = json.load(f)
 
                     # Translate relative indices [0, 1, 2] to their names and then to their new absolute indices
-                    new_annotations = [inverse_project_tags[label_tags[idx]]
-                                       for idx in annotation_data['time_annotation']]
+                    new_annotations = [inverse_tags[label_tags[idx]] for idx in annotation_data['time_annotation']]
                     annotation_data['time_annotation'] = new_annotations
 
                     with open(annotation_file, 'w') as f:
@@ -98,7 +97,7 @@ def _backwards_compatibility_update(path, config):
         updated = True
     else:
         # Translate string keys to integers (because JSON does not store integer keys)
-        config['project_tags'] = {int(idx_str): tag_name for idx_str, tag_name in config['project_tags'].items()}
+        config['tags'] = {int(idx_str): tag_name for idx_str, tag_name in config['tags'].items()}
 
     if updated:
         # Save updated config
@@ -137,7 +136,7 @@ def setup_new_project(project_name, path, config=None):
         config = {
             'name': project_name,
             'date_created': datetime.date.today().isoformat(),
-            'project_tags': {},
+            'tags': {},
             'max_tag_index': 0,
             'classes': {},
             'use_gpu': False,

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -194,12 +194,12 @@ def get_unique_project_name(base_name):
 
 def get_project_setting(path, setting):
     config = load_project_config(path)
-    return config.get(setting, False)
+    return config[setting]
 
 
 def toggle_project_setting(path, setting):
     config = load_project_config(path)
-    current_status = config.get(setting, False)
+    current_status = config[setting]
 
     new_status = not current_status
     config[setting] = new_status
@@ -211,8 +211,8 @@ def toggle_project_setting(path, setting):
 def get_timer_default(path):
     """Get the default countdown and recording duration (in seconds) for video-recording."""
     config = load_project_config(path)
-    countdown = config.get('video_recording', {}).get('countdown', 3)
-    duration = config.get('video_recording', {}).get('recording', 5)
+    countdown = config['video_recording']['countdown']
+    duration = config['video_recording']['recording']
 
     return countdown, duration
 
@@ -220,7 +220,7 @@ def get_timer_default(path):
 def set_timer_default(path, countdown, recording):
     """Set the new default countdown and recording duration (in seconds) for video-recording."""
     config = load_project_config(path)
-    video_recording = config.get('video_recording', {})
+    video_recording = config['video_recording']
 
     video_recording['countdown'] = countdown
     video_recording['recording'] = recording

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -71,6 +71,27 @@ def _backwards_compatibility_update(path, config):
             for class_name, class_tags in old_classes.items()
         }
 
+        # Translate existing annotations
+        for split in SPLITS:
+            tags_dir = directories.get_tags_dir(path, split)
+
+            for label in os.listdir(tags_dir):
+                label_dir = os.path.join(tags_dir, label)
+                label_tags = old_classes[label]
+                label_tags.insert(0, 'background')
+
+                for video_name in os.listdir(label_dir):
+                    annotation_file = os.path.join(label_dir, video_name)
+                    with open(annotation_file, 'r') as f:
+                        annotation_data = json.load(f)
+
+                    # Translate relative indices [0, 1, 2] to their names and then to their new absolute indices
+                    new_annotations = [project_tags[label_tags[idx]] for idx in annotation_data['time_annotation']]
+                    annotation_data['time_annotation'] = new_annotations
+
+                    with open(annotation_file, 'w') as f:
+                        json.dump(annotation_data, f, indent=2)
+
         updated = True
 
     if updated:

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -61,13 +61,14 @@ def _backwards_compatibility_update(path, config):
             project_tags_list.extend(class_tags)
 
         # Assign project-wide unique indices to tags
-        project_tags = {tag_name: idx + 1 for idx, tag_name in enumerate(project_tags_list)}
-        project_tags['background'] = 0
+        project_tags = {idx + 1: tag_name for idx, tag_name in enumerate(project_tags_list)}
+        project_tags[0] = 'background'
         config['project_tags'] = project_tags
 
         # Setup class dictionary with tag indices
+        inverse_project_tags = {tag_name: tag_idx for tag_idx, tag_name in project_tags.items()}
         config['classes'] = {
-            class_name: [project_tags[tag_name] for tag_name in class_tags]
+            class_name: [inverse_project_tags[tag_name] for tag_name in class_tags]
             for class_name, class_tags in old_classes.items()
         }
 
@@ -86,7 +87,8 @@ def _backwards_compatibility_update(path, config):
                         annotation_data = json.load(f)
 
                     # Translate relative indices [0, 1, 2] to their names and then to their new absolute indices
-                    new_annotations = [project_tags[label_tags[idx]] for idx in annotation_data['time_annotation']]
+                    new_annotations = [inverse_project_tags[label_tags[idx]]
+                                       for idx in annotation_data['time_annotation']]
                     annotation_data['time_annotation'] = new_annotations
 
                     with open(annotation_file, 'w') as f:
@@ -132,7 +134,7 @@ def setup_new_project(project_name, path, config=None):
             'name': project_name,
             'date_created': datetime.date.today().isoformat(),
             'project_tags': {
-                'background': 0,
+                0: 'background',
             },
             'classes': {},
             'use_gpu': False,

--- a/tools/sense_studio/project_utils.py
+++ b/tools/sense_studio/project_utils.py
@@ -96,6 +96,9 @@ def _backwards_compatibility_update(path, config):
                         json.dump(annotation_data, f, indent=2)
 
         updated = True
+    else:
+        # Translate string keys to integers (because JSON does not store integer keys)
+        config['project_tags'] = {int(idx_str): tag_name for idx_str, tag_name in config['project_tags'].items()}
 
     if updated:
         # Save updated config

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -29,7 +29,7 @@ from tools.sense_studio.annotation import annotation_bp
 from tools.sense_studio.testing import testing_bp
 from tools.sense_studio.training import training_bp
 from tools.sense_studio.video_recording import video_recording_bp
-from tools.sense_studio.project_tags import project_tags_bp
+from tools.sense_studio.project_tags import tags_bp
 
 app = Flask(__name__)
 app.secret_key = 'd66HR8dç"f_-àgjYYic*dh'
@@ -39,7 +39,7 @@ app.register_blueprint(annotation_bp, url_prefix='/annotation')
 app.register_blueprint(video_recording_bp, url_prefix='/video-recording')
 app.register_blueprint(training_bp, url_prefix='/training')
 app.register_blueprint(testing_bp, url_prefix='/testing')
-app.register_blueprint(project_tags_bp, url_prefix='/tags')
+app.register_blueprint(tags_bp, url_prefix='/tags')
 
 socketio.init_app(app)
 

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -349,7 +349,6 @@ def assign_tag_to_class():
     class_tags = config['classes'][class_name]
     class_tags.append(int(tag_index))
     class_tags.sort()
-    config['classes'][class_name] = class_tags
 
     project_utils.write_project_config(path, config)
     return jsonify(success=True)

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -29,7 +29,7 @@ from tools.sense_studio.annotation import annotation_bp
 from tools.sense_studio.testing import testing_bp
 from tools.sense_studio.training import training_bp
 from tools.sense_studio.video_recording import video_recording_bp
-from tools.sense_studio.project_tags import tags_bp
+from tools.sense_studio.tags import tags_bp
 
 app = Flask(__name__)
 app.secret_key = 'd66HR8dç"f_-àgjYYic*dh'
@@ -196,7 +196,7 @@ def project_details(project):
     config = project_utils.load_project_config(path)
 
     stats = {}
-    for class_name, tags in config['classes'].items():
+    for class_name in config['classes']:
         stats[class_name] = {}
         for split in SPLITS:
             videos_dir = directories.get_videos_dir(path, split, class_name)
@@ -205,9 +205,9 @@ def project_details(project):
                 'total': len(os.listdir(videos_dir)),
                 'tagged': len(os.listdir(tags_dir)) if os.path.exists(tags_dir) else 0,
             }
-    project_tags = config['project_tags']
+    tags = config['tags']
     return render_template('project_details.html', config=config, path=path, stats=stats, project=config['name'],
-                           project_tags=project_tags)
+                           tags=tags)
 
 
 @app.route('/add-class/<string:project>', methods=['POST'])

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -205,8 +205,7 @@ def project_details(project):
                 'total': len(os.listdir(videos_dir)),
                 'tagged': len(os.listdir(tags_dir)) if os.path.exists(tags_dir) else 0,
             }
-    project_tags = config.get('project_tags', {})
-    project_tags = {tag_idx: tag_name for tag_name, tag_idx in project_tags.items()}
+    project_tags = config['project_tags']
     return render_template('project_details.html', config=config, path=path, stats=stats, project=config['name'],
                            project_tags=project_tags)
 

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -153,11 +153,8 @@ def update_project():
     project_name = data['projectName']
     path = data['path']
 
-    try:
-        # Check for existing config file
-        config = project_utils.load_project_config(path)
-    except FileNotFoundError:
-        config = None
+    # Check for existing config file (might be None)
+    config = project_utils.load_project_config(path)
 
     # Make sure the directory is correctly set up
     project_utils.setup_new_project(project_name, path, config)
@@ -175,13 +172,12 @@ def import_project():
     data = request.form
     path = data['path']
 
-    try:
-        # Check for existing config file and make sure project name is unique
-        config = project_utils.load_project_config(path)
+    # Check for existing config file and make sure project name is unique
+    config = project_utils.load_project_config(path)
+    if config:
         project_name = project_utils.get_unique_project_name(config['name'])
-    except FileNotFoundError:
+    else:
         # Use folder name as project name and make sure it is unique
-        config = None
         project_name = project_utils.get_unique_project_name(os.path.basename(path))
 
     # Make sure the directory is correctly set up

--- a/tools/sense_studio/static/main.css
+++ b/tools/sense_studio/static/main.css
@@ -49,36 +49,6 @@ video {
     color: #fff;
 }
 
-.label-green {
-    background: #00cc00;
-    color: #fff;
-}
-
-.button-grey {
-    background: #9f9f9f;
-    color: #fff;
-}
-
-.button-grey:focus, .button-grey:hover {
-    background: #8f8f8f;
-    color: #fff;
-}
-
-.label-grey {
-    background: #9f9f9f;
-    color: #fff;
-}
-
-.button-blue {
-    background: #0e73d8;
-    color: #fff;
-}
-
-.button-blue:focus, .button-blue:hover {
-    background: #0c66c0;
-    color: #fff;
-}
-
 .label-blue {
     background: #0e73d8;
     color: #fff;

--- a/tools/sense_studio/static/main.css
+++ b/tools/sense_studio/static/main.css
@@ -57,3 +57,8 @@ video {
 .line-height-normal {
     line-height: normal;
 }
+
+.narrow-button {
+    padding-left: 10px;
+    padding-right: 10px;
+}

--- a/tools/sense_studio/static/main.css
+++ b/tools/sense_studio/static/main.css
@@ -39,18 +39,18 @@ video {
 }
 
 /* Additional colors for buttons and labels */
-.button-green {
-    background: #00cc00;
+.button-grey {
+    background: #9f9f9f;
     color: #fff;
 }
 
-.button-green:focus, .button-green:hover {
-    background: #00b300;
+.button-grey:focus, .button-grey:hover {
+    background: #8f8f8f;
     color: #fff;
 }
 
-.label-blue {
-    background: #0e73d8;
+.label-grey {
+    background: #9f9f9f;
     color: #fff;
 }
 

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -272,11 +272,12 @@ function assignTag(frameIdx, selectedTagIdx,  classTagIndices) {
     for (const tagIdx of classTagIndices) {
 
         let button = document.getElementById(`${frameIdx}_tag${tagIdx}`);
+        let buttonColor = tagIdx == 0 ? 'button-grey' : 'uk-button-primary';
 
         if (tagIdx == selectedTagIdx) {
-            button.classList.add('button-green');
+            button.classList.add(buttonColor);
         } else {
-            button.classList.remove('button-green');
+            button.classList.remove(buttonColor);
         }
     }
 }

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -398,20 +398,20 @@ async function deselectTagFromList(classIdx, tagIndex, tagName, path, className)
     }
 }
 
-///////////////////////////////////////////// Project Tags Operations //////////////////////////////////////////////////
+///////////////////////////////////////////// Tag Operations //////////////////////////////////////////////////
 
-function checkIfTagExist(projectTags, tagId, errorLabelId, tagOperation, originalTagName) {
+function checkIfTagExist(tags, tagId, errorLabelId, tagOperation, originalTagName) {
     let tag = document.getElementById(tagId);
     let errorLabel = document.getElementById(errorLabelId);
     let tagButton = document.getElementById(tagOperation);
-    let projectTagNames = Object.values(projectTags);
+    let tagNames = Object.values(tags);
 
     let disabled = false;
 
     if (tag.value === '') {
         setFormWarning(errorLabel, tag, '');
         disabled = true;
-    } else if (tag.value !== originalTagName && projectTagNames.includes(tag.value)) {
+    } else if (tag.value !== originalTagName && tagNames.includes(tag.value)) {
         setFormWarning(errorLabel, tag, 'This tag name already exist');
         disabled = true;
     } else if (tag.value === 'background') {
@@ -425,7 +425,7 @@ function checkIfTagExist(projectTags, tagId, errorLabelId, tagOperation, origina
 }
 
 
-function editProjectTag(tagIdx) {
+function editTag(tagIdx) {
     let tagShow = document.getElementById(`tagShow${tagIdx}`);
     let tagEdit = document.getElementById(`tagEdit${tagIdx}`);
 
@@ -434,7 +434,7 @@ function editProjectTag(tagIdx) {
 }
 
 
-function cancelEditProjectTag(tagIdx) {
+function cancelEditTag(tagIdx) {
     let tagShow = document.getElementById(`tagShow${tagIdx}`);
     let tagEdit = document.getElementById(`tagEdit${tagIdx}`);
     let tag = document.getElementById(`tag${tagIdx}`);

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -414,7 +414,7 @@ function checkIfTagExist(tags, tagId, errorLabelId, tagOperation, originalTagNam
     } else if (tag.value !== originalTagName && tagNames.includes(tag.value)) {
         setFormWarning(errorLabel, tag, 'This tag name already exist');
         disabled = true;
-    } else if (tag.value === 'background') {
+    } else if (tag.value.toLowerCase() === 'background') {
         setFormWarning(errorLabel, tag, 'This name is reserved');
         disabled = true;
     } else {

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -403,7 +403,7 @@ function checkIfTagExist(projectTags, tagId, errorLabelId, tagOperation, origina
     let tag = document.getElementById(tagId);
     let errorLabel = document.getElementById(errorLabelId);
     let tagButton = document.getElementById(tagOperation);
-    projectTagNames = Object.values(projectTags);
+    let projectTagNames = Object.values(projectTags);
 
     let disabled = false;
 
@@ -412,6 +412,9 @@ function checkIfTagExist(projectTags, tagId, errorLabelId, tagOperation, origina
         disabled = true;
     } else if (tag.value !== originalTagName && projectTagNames.includes(tag.value)) {
         setFormWarning(errorLabel, tag, 'This tag name already exist');
+        disabled = true;
+    } else if (tag.value === 'background') {
+        setFormWarning(errorLabel, tag, 'This name is reserved');
         disabled = true;
     } else {
         setFormWarning(errorLabel, tag, '');

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -399,7 +399,7 @@ async function deselectTagFromList(classIdx, tagIndex, tagName, path, className)
 
 ///////////////////////////////////////////// Project Tags Operations //////////////////////////////////////////////////
 
-function checkIfTagExist(projectTags, tagId, errorLabelId, tagOperation) {
+function checkIfTagExist(projectTags, tagId, errorLabelId, tagOperation, originalTagName) {
     let tag = document.getElementById(tagId);
     let errorLabel = document.getElementById(errorLabelId);
     let tagButton = document.getElementById(tagOperation);
@@ -410,7 +410,7 @@ function checkIfTagExist(projectTags, tagId, errorLabelId, tagOperation) {
     if (tag.value === '') {
         setFormWarning(errorLabel, tag, '');
         disabled = true;
-    } else if (projectTagNames.includes(tag.value)) {
+    } else if (tag.value !== originalTagName && projectTagNames.includes(tag.value)) {
         setFormWarning(errorLabel, tag, 'This tag name already exist');
         disabled = true;
     } else {

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -434,7 +434,7 @@ function cancelEditProjectTag(tagIdx) {
     let tagEdit = document.getElementById(`tagEdit${tagIdx}`);
     let tag = document.getElementById(`tag${tagIdx}`);
     let project = document.getElementById('projectName').value;
-    let error = document.getElementById('error');
+    let error = document.getElementById(`tagEditError${tagIdx}`);
 
     setFormWarning(error, tag, '');
 

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -194,7 +194,6 @@ async function editAddClass(projectName) {
 
 
 async function editUpdateClass(projectName, originalClassName, index) {
-    console.log(`editClassName${index}`);
     let classNameInput = document.getElementById(`editClassName${index}`);
     let classNameLabel = document.getElementById(`editClassNameLabel${index}`);
     let editClassButton = document.getElementById(`submitEditClass${index}`);
@@ -293,6 +292,7 @@ function initTagButtons(annotations, classTagIndices) {
 function editClass(index, shouldEdit) {
     let classShow = document.getElementById(`classShow${index}`);
     let classEdit = document.getElementById(`classEdit${index}`);
+    let className = document.getElementById(`editClassName${index}`);
 
     if (shouldEdit) {
         classShow.classList.add('uk-hidden');
@@ -300,6 +300,7 @@ function editClass(index, shouldEdit) {
     } else {
         classShow.classList.remove('uk-hidden');
         classEdit.classList.add('uk-hidden');
+        className.value = className.attributes.value.value;
     }
 }
 

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -429,44 +429,6 @@ function editProjectTag(tagIdx) {
 }
 
 
-async function saveProjectTag(tagIdx, url, projectTags) {
-    let tag = document.getElementById(`tag${tagIdx}`);
-    let tagShow = document.getElementById(`tagShow${tagIdx}`);
-    let tagEdit = document.getElementById(`tagEdit${tagIdx}`);
-    let path = document.getElementById('path').value;
-    let project = document.getElementById('projectName').value;
-
-    data = {
-        path: path,
-        tagIdx: tagIdx,
-        newTagName: tag.value,
-    };
-
-    let response = await asyncRequest(url, data);
-
-    if (response.success) {
-        tagEdit.classList.add('uk-hidden');
-        tagShow.classList.remove('uk-hidden');
-        window.location.href = `/project/${project}`;
-    }
-}
-
-
-async function removeProjectTag(tagIdx, url) {
-    let project = document.getElementById('projectName').value;
-    let path = document.getElementById('path').value;
-    data = {
-        path: path,
-        tagIdx: tagIdx,
-    };
-
-    let response = await asyncRequest(url, data);
-    if (response.success) {
-        window.location.href = `/project/${project}`;
-    }
-}
-
-
 function cancelEditProjectTag(tagIdx) {
     let tagShow = document.getElementById(`tagShow${tagIdx}`);
     let tagEdit = document.getElementById(`tagEdit${tagIdx}`);

--- a/tools/sense_studio/tags.py
+++ b/tools/sense_studio/tags.py
@@ -10,7 +10,7 @@ from tools.sense_studio import project_utils
 tags_bp = Blueprint('tags_bp', __name__)
 
 
-@tags_bp.route('/create-project-tag/<string:project>', methods=['POST'])
+@tags_bp.route('/create-tag/<string:project>', methods=['POST'])
 def create_tag(project):
     data = request.form
     project = urllib.parse.unquote(project)
@@ -18,45 +18,45 @@ def create_tag(project):
     config = project_utils.load_project_config(path)
     tag_name = data['newTagName']
 
-    project_tags = config['project_tags']
+    tags = config['tags']
     new_tag_index = config['max_tag_index'] + 1
-    project_tags[new_tag_index] = tag_name
+    tags[new_tag_index] = tag_name
     config['max_tag_index'] = new_tag_index
 
     project_utils.write_project_config(path, config)
     return redirect(url_for('project_details', project=project))
 
 
-@tags_bp.route('/remove-project-tag/<string:project>/<int:tag_idx>')
+@tags_bp.route('/remove-tag/<string:project>/<int:tag_idx>')
 def remove_tag(project, tag_idx):
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
     config = project_utils.load_project_config(path)
-    project_tags = config['project_tags']
+    tags = config['tags']
 
-    # Remove tag from the project tags list
-    del project_tags[tag_idx]
+    # Remove tag from the overall tags list
+    del tags[tag_idx]
 
     # Remove tag from the classes
-    for class_label, tags in config['classes'].items():
-        if tag_idx in tags:
-            tags.remove(tag_idx)
+    for class_label, class_tags in config['classes'].items():
+        if tag_idx in class_tags:
+            class_tags.remove(tag_idx)
 
     project_utils.write_project_config(path, config)
     return redirect(url_for('project_details', project=project))
 
 
-@tags_bp.route('/edit-project-tag/<string:project>/<int:tag_idx>', methods=['POST'])
+@tags_bp.route('/edit-tag/<string:project>/<int:tag_idx>', methods=['POST'])
 def edit_tag(project, tag_idx):
     data = request.form
     project = urllib.parse.unquote(project)
     path = project_utils.lookup_project_path(project)
     config = project_utils.load_project_config(path)
-    project_tags = config['project_tags']
+    tags = config['tags']
     new_tag_name = data['newTagName']
 
     # Update tag name
-    project_tags[tag_idx] = new_tag_name
+    tags[tag_idx] = new_tag_name
 
     project_utils.write_project_config(path, config)
     return redirect(url_for('project_details', project=project))

--- a/tools/sense_studio/templates/frame_annotation.html
+++ b/tools/sense_studio/templates/frame_annotation.html
@@ -94,11 +94,11 @@
                         <img src="{{ url_for('annotation_bp.download_file', project=project, split=split, label=label, video_name=video_name, img_file=img) }}">
                     </div>
                     <div class="uk-card-body">
-                        <div class="uk-margin {{ 'uk-hidden' if not project_config.assisted_tagging }}">
+                        <div class="{{ 'uk-hidden' if not project_config.assisted_tagging }}">
                             {% if pred_class >= 0 %}
-                                <div class="uk-label {{ 'label-grey' if pred_class == 0 }}">
+                                <div class="uk-label {{ 'label-grey' if pred_class == 0 }} uk-margin">
                                     <span class="uk-text-bolder">
-                                        {{ project_tags[pred_class] }}
+                                        {{ tags[pred_class] }}
                                     </span>
                                     <span class="uk-text-lowercase uk-text-small">
                                         predicted
@@ -112,7 +112,7 @@
                                     <button type="button" class="uk-button uk-width-1-1"
                                             id="{{ img_index }}_tag{{ tag_index }}"
                                             onclick="assignTag({{ img_index }}, {{ tag_index }}, {{ class_tags }});">
-                                        {{ project_tags[tag_index] }}
+                                        {{ tags[tag_index] }}
                                     </button>
                                 </div>
                             {% endfor %}

--- a/tools/sense_studio/templates/frame_annotation.html
+++ b/tools/sense_studio/templates/frame_annotation.html
@@ -86,7 +86,7 @@
 
         <div class="uk-child-width-1-2@s uk-child-width-1-3@m uk-child-width-1-4@l" uk-grid>
             {% for img, pred_class in images %}
-            {% set img_idx = loop.index0 %}
+            {% set img_index = loop.index0 %}
             <div>
                 <input type="hidden" id="{{ loop.index0 }}_tag" name="{{ loop.index0 }}_tag" value="0">
                 <div class="uk-card uk-card-default">
@@ -94,9 +94,9 @@
                         <img src="{{ url_for('annotation_bp.download_file', project=project, split=split, label=label, video_name=video_name, img_file=img) }}">
                     </div>
                     <div class="uk-card-body">
-                        <div class="{{ 'uk-hidden' if not project_config.assisted_tagging }}">
-                            {% if pred_class in class_tags %}
-                                <div class="uk-label label-blue">
+                        <div class="uk-margin {{ 'uk-hidden' if not project_config.assisted_tagging }}">
+                            {% if pred_class >= 0 %}
+                                <div class="uk-label {{ 'label-grey' if pred_class == 0 }}">
                                     <span class="uk-text-bolder">
                                         {{ project_tags[pred_class] }}
                                     </span>
@@ -106,7 +106,7 @@
                                 </div>
                             {% endif %}
                         </div>
-                        <div class="uk-grid-collapse uk-margin">
+                        <div class="uk-grid-collapse">
                             {% for tag_index in class_tags %}
                                 <div>
                                     <button type="button" class="uk-button uk-width-1-1"

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -100,7 +100,7 @@
 
     <div class="temporal {{ 'uk-hidden' if not config.temporal }}">
         <div class="uk-child-width-1-2@m uk-child-width-1-3@l uk-grid-match" uk-grid>
-            {% for tag_idx, tag_name in project_tags.items() %}
+            {% for tag_idx, tag_name in project_tags.items()|sort(attribute='1') %}
             <div>
                 <div class="uk-card uk-card-default uk-card-hover uk-card-header">
                     <div id="tagShow{{ tag_idx }}" class="uk-grid-small" uk-grid>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -117,7 +117,7 @@
                                     Remove tag from the config. All annotations with this tag will be lost.
                                 </p>
                                 <a class="uk-button uk-button-danger"
-                                    href="{{ url_for('project_tags_bp.remove_tag_from_project_tags', project=project, remove_tag_idx=tag_idx) }}">
+                                    href="{{ url_for('project_tags_bp.remove_tag_from_project_tags', project=project, tag_idx=tag_idx) }}">
                                     <span uk-icon="icon: trash"></span> REMOVE
                                 </a>
                             </div>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -118,7 +118,7 @@
                                     Remove tag from the config. All annotations with this tag will be lost.
                                 </p>
                                 <a class="uk-button uk-button-danger"
-                                    onclick="removeProjectTag('{{ tag_idx }}', '{{ url_for('project_tags_bp.remove_tag_from_project_tags', project=project) }}');">
+                                    href="{{ url_for('project_tags_bp.remove_tag_from_project_tags', project=project, remove_tag_idx=tag_idx) }}">
                                     <span uk-icon="icon: trash"></span> REMOVE
                                 </a>
                             </div>
@@ -126,17 +126,16 @@
                     </div>
 
                     <div id="tagEdit{{ tag_idx }}" class="uk-hidden">
-                        <form>
+                        <form method="POST" action="{{ url_for('project_tags_bp.edit_tag_in_project_tags', project=project, tag_idx=tag_idx) }}">
                             <div class="uk-form-control">
                                 <div class="uk-inline uk-width-1-1 uk-margin-bottom">
                                     <span class="uk-form-icon" uk-icon="icon: tag"></span>
                                     <input class="uk-input" type="text" placeholder="Tag name" autocomplete="off"
-                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'error', 'saveTag{{ tag_idx }}');" id="tag{{ tag_idx }}"
-                                           value="{{ tag_name }}" autocomplete="off">
+                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'error', 'saveTag{{ tag_idx }}');"
+                                           id="tag{{ tag_idx }}" name="newTagName" value="{{ tag_name }}" autocomplete="off">
                                 </div>
                             </div>
-                            <button class="uk-button uk-button-primary" type="button" uk-tooltip="Save Tag" id="saveTag{{ tag_idx }}"
-                               onclick="saveProjectTag('{{ tag_idx }}', '{{ url_for('project_tags_bp.edit_tag_in_project_tags', project=project) }}', {{ project_tags }});">
+                            <button class="uk-button uk-button-primary" type="submit" uk-tooltip="Save Tag" id="saveTag{{ tag_idx }}">
                                 <span uk-icon="icon: check"></span>
                             </button>
                             <a class="uk-button uk-button-danger" uk-tooltip="Cancel" onclick="cancelEditProjectTag('{{ tag_idx }}');">

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -126,21 +126,24 @@
                     </div>
 
                     <div id="tagEdit{{ tag_idx }}" class="uk-hidden">
-                        <form method="POST" action="{{ url_for('project_tags_bp.edit_tag_in_project_tags', project=project, tag_idx=tag_idx) }}">
-                            <div class="uk-form-control">
-                                <div class="uk-inline uk-width-1-1 uk-margin-bottom">
+                        <form method="POST" class="uk-grid-small"
+                              action="{{ url_for('project_tags_bp.edit_tag_in_project_tags', project=project, tag_idx=tag_idx) }}" uk-grid>
+                            <div class="uk-form-control uk-width-expand">
+                                <div class="uk-inline">
                                     <span class="uk-form-icon" uk-icon="icon: tag"></span>
                                     <input class="uk-input" type="text" placeholder="Tag name" autocomplete="off"
                                            oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'error', 'saveTag{{ tag_idx }}');"
                                            id="tag{{ tag_idx }}" name="newTagName" value="{{ tag_name }}" autocomplete="off">
                                 </div>
                             </div>
-                            <button class="uk-button uk-button-primary" type="submit" uk-tooltip="Save Tag" id="saveTag{{ tag_idx }}">
-                                <span uk-icon="icon: check"></span>
-                            </button>
-                            <a class="uk-button uk-button-danger" uk-tooltip="Cancel" onclick="cancelEditProjectTag('{{ tag_idx }}');">
-                                <span uk-icon="icon: close"></span>
-                            </a>
+                            <div class="uk-width-auto">
+                                <button class="uk-button uk-button-primary narrow-button" type="submit" uk-tooltip="Save Tag" id="saveTag{{ tag_idx }}">
+                                    <span uk-icon="icon: check"></span>
+                                </button>
+                                <a class="uk-button uk-button-danger narrow-button" uk-tooltip="Cancel" onclick="cancelEditProjectTag('{{ tag_idx }}');">
+                                    <span uk-icon="icon: close"></span>
+                                </a>
+                            </div>
                         </form>
                     </div>
                 </div>
@@ -211,22 +214,25 @@
                         </div>
 
                         <div id="classEdit{{ class_idx }}" class="uk-hidden">
-                            <form method="POST" action="{{ url_for('edit_class', project=project, class_name=class) }}">
-                                <div>
+                            <form method="POST" class="uk-grid-small"
+                                  action="{{ url_for('edit_class', project=project, class_name=class) }}" uk-grid>
+                                <div class="uk-width-expand">
                                     <label class="uk-form-label uk-text-danger" id="editClassNameLabel{{ class_idx }}"></label>
-                                    <div class="uk-inline uk-width-1-1 uk-margin-bottom">
+                                    <div class="uk-inline">
                                         <span class="uk-form-icon" uk-icon="icon: bookmark"></span>
                                         <input class="uk-input" type="text" id="editClassName{{ class_idx }}" name="className"
                                                placeholder="Class Name" value="{{ class }}" autocomplete="off"
                                                oninput="editUpdateClass('{{ project }}', '{{ class }}', '{{ class_idx }}');">
                                     </div>
                                 </div>
-                                <button class="uk-button uk-button-primary" type="submit" id="submitEditClass{{ class_idx }}" uk-tooltip="Save Changes">
-                                    <span uk-icon="icon: check"></span>
-                                </button>
-                                <a class="uk-button uk-button-danger" uk-tooltip="Cancel" onclick="editClass('{{ class_idx }}', false);">
-                                    <span uk-icon="icon: close"></span>
-                                </a>
+                                <div class="uk-width-auto">
+                                    <button class="uk-button uk-button-primary narrow-button" type="submit" id="submitEditClass{{ class_idx }}" uk-tooltip="Save Changes">
+                                        <span uk-icon="icon: check"></span>
+                                    </button>
+                                    <a class="uk-button uk-button-danger narrow-button" uk-tooltip="Cancel" onclick="editClass('{{ class_idx }}', false);">
+                                        <span uk-icon="icon: close"></span>
+                                    </a>
+                                </div>
                             </form>
                         </div>
                     </div>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -188,7 +188,7 @@
     </div>
 
     <div class="uk-child-width-1-2@m uk-child-width-1-3@l" uk-grid>
-        {% for class, selected_tags in config.classes|dictsort %}
+        {% for class, selected_tags in config.classes.items()|sort %}
             {% set class_idx = loop.index %}
             <div>
                 <div class="uk-card uk-card-default uk-card-hover">
@@ -247,7 +247,7 @@
                                 onchange="addSelectedTagToClass('{{ class_idx }}', '{{ class }}', '{{ path }}');">
                             {% if project_tags %}
                                 <option value="">Select tags...</option>
-                                {% for tag_index, tag_name in project_tags.items() %}
+                                {% for tag_index, tag_name in project_tags.items()|sort(attribute='1') %}
                                     {% if tag_index not in selected_tags %}
                                         <option value="{{ tag_index }}">{{ tag_name }}</option>
                                     {% endif %}

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -99,7 +99,6 @@
     </div>
 
     <div class="temporal {{ 'uk-hidden' if not config.temporal }}">
-        <h5 id="error" class="uk-text-danger uk-text-center"></h5>
         <div class="uk-child-width-1-2@m uk-child-width-1-3@l uk-grid-match" uk-grid>
             {% for tag_idx, tag_name in project_tags.items() %}
             <div>
@@ -128,15 +127,18 @@
                     <div id="tagEdit{{ tag_idx }}" class="uk-hidden">
                         <form method="POST" class="uk-grid-small"
                               action="{{ url_for('project_tags_bp.edit_tag_in_project_tags', project=project, tag_idx=tag_idx) }}" uk-grid>
-                            <div class="uk-form-control uk-width-expand">
+                            <div class="uk-width-1-1">
+                                <label id="tagEditError{{ tag_idx }}" class="uk-form-label uk-text-danger"></label>
+                            </div>
+                            <div class="uk-form-control uk-width-expand uk-margin-remove-top">
                                 <div class="uk-inline">
                                     <span class="uk-form-icon" uk-icon="icon: tag"></span>
                                     <input class="uk-input" type="text" placeholder="Tag name" autocomplete="off"
-                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'error', 'saveTag{{ tag_idx }}');"
+                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'tagEditError{{ tag_idx }}', 'saveTag{{ tag_idx }}');"
                                            id="tag{{ tag_idx }}" name="newTagName" value="{{ tag_name }}" autocomplete="off">
                                 </div>
                             </div>
-                            <div class="uk-width-auto">
+                            <div class="uk-width-auto uk-margin-remove-top">
                                 <button class="uk-button uk-button-primary narrow-button" type="submit" uk-tooltip="Save Tag" id="saveTag{{ tag_idx }}">
                                     <span uk-icon="icon: check"></span>
                                 </button>
@@ -216,8 +218,10 @@
                         <div id="classEdit{{ class_idx }}" class="uk-hidden">
                             <form method="POST" class="uk-grid-small"
                                   action="{{ url_for('edit_class', project=project, class_name=class) }}" uk-grid>
-                                <div class="uk-width-expand">
+                                <div class="uk-width-1-1">
                                     <label class="uk-form-label uk-text-danger" id="editClassNameLabel{{ class_idx }}"></label>
+                                </div>
+                                <div class="uk-width-expand uk-margin-remove-top">
                                     <div class="uk-inline">
                                         <span class="uk-form-icon" uk-icon="icon: bookmark"></span>
                                         <input class="uk-input" type="text" id="editClassName{{ class_idx }}" name="className"
@@ -225,7 +229,7 @@
                                                oninput="editUpdateClass('{{ project }}', '{{ class }}', '{{ class_idx }}');">
                                     </div>
                                 </div>
-                                <div class="uk-width-auto">
+                                <div class="uk-width-auto uk-margin-remove-top">
                                     <button class="uk-button uk-button-primary narrow-button" type="submit" id="submitEditClass{{ class_idx }}" uk-tooltip="Save Changes">
                                         <span uk-icon="icon: check"></span>
                                     </button>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -134,7 +134,7 @@
                                 <div class="uk-inline">
                                     <span class="uk-form-icon" uk-icon="icon: tag"></span>
                                     <input class="uk-input" type="text" placeholder="Tag name" autocomplete="off"
-                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'tagEditError{{ tag_idx }}', 'saveTag{{ tag_idx }}', {{ tag_name }});"
+                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'tagEditError{{ tag_idx }}', 'saveTag{{ tag_idx }}', '{{ tag_name }}');"
                                            id="tag{{ tag_idx }}" name="newTagName" value="{{ tag_name }}" autocomplete="off">
                                 </div>
                             </div>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -134,7 +134,7 @@
                                 <div class="uk-inline">
                                     <span class="uk-form-icon" uk-icon="icon: tag"></span>
                                     <input class="uk-input" type="text" placeholder="Tag name" autocomplete="off"
-                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'tagEditError{{ tag_idx }}', 'saveTag{{ tag_idx }}');"
+                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'tagEditError{{ tag_idx }}', 'saveTag{{ tag_idx }}', {{ tag_name }});"
                                            id="tag{{ tag_idx }}" name="newTagName" value="{{ tag_name }}" autocomplete="off">
                                 </div>
                             </div>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -84,7 +84,7 @@
                             <div class="uk-inline uk-width-1-1 uk-margin-bottom">
                                 <span class="uk-form-icon" uk-icon="icon: tag"></span>
                                 <input class="uk-input" type="text" id="newTagName" name="newTagName" placeholder="Tag Name"
-                                       oninput="checkIfTagExist({{ project_tags }}, 'newTagName', 'newTagLabel', 'addTag');" autocomplete="off">
+                                       oninput="checkIfTagExist({{ tags }}, 'newTagName', 'newTagLabel', 'addTag');" autocomplete="off">
                             </div>
                         </div>
 
@@ -100,7 +100,7 @@
 
     <div class="temporal {{ 'uk-hidden' if not config.temporal }}">
         <div class="uk-child-width-1-2@m uk-child-width-1-3@l uk-grid-match" uk-grid>
-            {% for tag_idx, tag_name in project_tags.items()|sort(attribute='1') %}
+            {% for tag_idx, tag_name in tags.items()|sort(attribute='1') %}
             <div>
                 <div class="uk-card uk-card-default uk-card-hover uk-card-header">
                     <div id="tagShow{{ tag_idx }}" class="uk-grid-small" uk-grid>
@@ -108,7 +108,7 @@
                             <h3 class="uk-card-title uk-float-left">{{ tag_name }}</h3>
                         </div>
                         <div class="uk-width-auto">
-                            <a uk-icon="icon: pencil; ratio: 1.1" uk-tooltip="Edit Tag" onclick="editProjectTag('{{ tag_idx }}');"></a>
+                            <a uk-icon="icon: pencil; ratio: 1.1" uk-tooltip="Edit Tag" onclick="editTag('{{ tag_idx }}');"></a>
                         </div>
                         <div class="uk-width-auto">
                             <a href="#" uk-icon="icon: trash; ratio: 1.1" uk-tooltip="Remove Tag"></a>
@@ -134,7 +134,7 @@
                                 <div class="uk-inline">
                                     <span class="uk-form-icon" uk-icon="icon: tag"></span>
                                     <input class="uk-input" type="text" placeholder="Tag name" autocomplete="off"
-                                           oninput="checkIfTagExist({{ project_tags }}, 'tag{{ tag_idx }}', 'tagEditError{{ tag_idx }}', 'saveTag{{ tag_idx }}', '{{ tag_name }}');"
+                                           oninput="checkIfTagExist({{ tags }}, 'tag{{ tag_idx }}', 'tagEditError{{ tag_idx }}', 'saveTag{{ tag_idx }}', '{{ tag_name }}');"
                                            id="tag{{ tag_idx }}" name="newTagName" value="{{ tag_name }}" autocomplete="off">
                                 </div>
                             </div>
@@ -142,7 +142,7 @@
                                 <button class="uk-button uk-button-primary narrow-button" type="submit" uk-tooltip="Save Tag" id="saveTag{{ tag_idx }}">
                                     <span uk-icon="icon: check"></span>
                                 </button>
-                                <a class="uk-button uk-button-danger narrow-button" uk-tooltip="Cancel" onclick="cancelEditProjectTag('{{ tag_idx }}');">
+                                <a class="uk-button uk-button-danger narrow-button" uk-tooltip="Cancel" onclick="cancelEditTag('{{ tag_idx }}');">
                                     <span uk-icon="icon: close"></span>
                                 </a>
                             </div>
@@ -245,9 +245,9 @@
                         <h4>Tags</h4>
                         <select class="uk-select" id="selectTag{{ class_idx }}"
                                 onchange="addSelectedTagToClass('{{ class_idx }}', '{{ class }}', '{{ path }}');">
-                            {% if project_tags %}
+                            {% if tags %}
                                 <option value="">Select tags...</option>
-                                {% for tag_index, tag_name in project_tags.items()|sort(attribute='1') %}
+                                {% for tag_index, tag_name in tags.items()|sort(attribute='1') %}
                                     {% if tag_index not in selected_tags %}
                                         <option value="{{ tag_index }}">{{ tag_name }}</option>
                                     {% endif %}
@@ -261,10 +261,10 @@
                                 {% for tag_idx in selected_tags %}
                                     <li id="tagList{{ class_idx }}-{{ tag_idx }}">
                                         <span uk-icon="icon: tag"></span>
-                                        {{ project_tags[tag_idx] }}
+                                        {{ tags[tag_idx] }}
                                         <a class="uk-float-right">
                                             <span uk-icon="icon: close" class="uk-text-danger"
-                                                  onclick="deselectTagFromList('{{ class_idx }}', '{{ tag_idx }}','{{ project_tags[tag_idx] }}', '{{ path }}', '{{ class }}');">
+                                                  onclick="deselectTagFromList('{{ class_idx }}', '{{ tag_idx }}','{{ tags[tag_idx] }}', '{{ path }}', '{{ class }}');">
                                             </span>
                                         </a>
                                     </li>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -77,7 +77,7 @@
             </button>
             <div class="uk-width-large" uk-drop="pos: bottom-center; mode:click">
                 <form class="uk-card uk-card-default uk-card-hover uk-form-stacked" method="POST"
-                      action="{{ url_for('project_tags_bp.create_tag_in_project_tags', project=project) }}">
+                      action="{{ url_for('tags_bp.create_tag', project=project) }}">
                     <div class="uk-card-body">
                         <div>
                             <label class="uk-form-label uk-text-danger" id="newTagLabel"></label>
@@ -117,7 +117,7 @@
                                     Remove tag from the config. All annotations with this tag will be lost.
                                 </p>
                                 <a class="uk-button uk-button-danger"
-                                    href="{{ url_for('project_tags_bp.remove_tag_from_project_tags', project=project, tag_idx=tag_idx) }}">
+                                    href="{{ url_for('tags_bp.remove_tag', project=project, tag_idx=tag_idx) }}">
                                     <span uk-icon="icon: trash"></span> REMOVE
                                 </a>
                             </div>
@@ -126,7 +126,7 @@
 
                     <div id="tagEdit{{ tag_idx }}" class="uk-hidden">
                         <form method="POST" class="uk-grid-small"
-                              action="{{ url_for('project_tags_bp.edit_tag_in_project_tags', project=project, tag_idx=tag_idx) }}" uk-grid>
+                              action="{{ url_for('tags_bp.edit_tag', project=project, tag_idx=tag_idx) }}" uk-grid>
                             <div class="uk-width-1-1">
                                 <label id="tagEditError{{ tag_idx }}" class="uk-form-label uk-text-danger"></label>
                             </div>

--- a/tools/sense_studio/utils.py
+++ b/tools/sense_studio/utils.py
@@ -71,8 +71,8 @@ def train_logreg(path, split, label):
     all_features = []
     all_annotations = []
 
-    for features in feature_files:
-        features = np.load(features)
+    for feature_file in feature_files:
+        features = np.load(feature_file)
 
         for f in features:
             all_features.append(f.mean(axis=(1, 2)))
@@ -88,13 +88,13 @@ def train_logreg(path, split, label):
 
     # Use low class weight for background and higher weight for all present tags
     annotated_tags = set(all_annotations)
-    class_weight = {0: 0.5}
-    class_weight.update({tag: 2 for tag in annotated_tags})
+    class_weight = {tag: 2 for tag in annotated_tags}
+    class_weight[0] = 0.5
 
     all_features = np.array(all_features)
     all_annotations = np.array(all_annotations)
 
-    if len(class_weight) > 1:
+    if len(annotated_tags) > 1:
         logreg = LogisticRegression(C=0.1, class_weight=class_weight)
         logreg.fit(all_features, all_annotations)
         dump(logreg, logreg_path)

--- a/tools/sense_studio/utils.py
+++ b/tools/sense_studio/utils.py
@@ -10,6 +10,7 @@ from sense.loading import build_backbone_network
 from sense.loading import get_relevant_weights
 from sense.loading import ModelConfig
 from tools import directories
+from tools.sense_studio.project_utils import load_project_config
 from tools.sense_studio.project_utils import get_project_setting
 
 SUPPORTED_MODEL_CONFIGURATIONS = [
@@ -57,54 +58,43 @@ def train_logreg(path, split, label):
     tags_dir = directories.get_tags_dir(path, split, label)
     logreg_dir = directories.get_logreg_dir(path, model_config, label)
     logreg_path = os.path.join(logreg_dir, 'logreg.joblib')
+    project_config = load_project_config(path)
+    class_tags = project_config['classes'][label]
 
-    annotations = os.listdir(tags_dir) if os.path.exists(tags_dir) else None
-
-    if not annotations:
+    if not os.path.exists(tags_dir):
         return
 
-    features = [os.path.join(features_dir, x.replace('.json', '.npy')) for x in annotations]
-    annotations = [os.path.join(tags_dir, x) for x in annotations]
-    x = []
-    y = []
+    annotation_files = os.listdir(tags_dir)
 
+    feature_files = [os.path.join(features_dir, x.replace('.json', '.npy')) for x in annotation_files]
+    annotation_files = [os.path.join(tags_dir, x) for x in annotation_files]
+    all_features = []
+    all_annotations = []
+
+    for features in feature_files:
+        features = np.load(features)
+
+        for f in features:
+            all_features.append(f.mean(axis=(1, 2)))
+
+    for annotation_file in annotation_files:
+        with open(annotation_file, 'r') as f:
+            annotations = json.load(f)['time_annotation']
+
+        all_annotations.extend(annotations)
+
+    # Reset tags that have been removed from the class to 'background'
+    all_annotations = [tag_idx if tag_idx in class_tags else 0 for tag_idx in all_annotations]
+
+    # Use low class weight for background and higher weight for all present tags
+    annotated_tags = set(all_annotations)
     class_weight = {0: 0.5}
+    class_weight.update({tag: 2 for tag in annotated_tags})
 
-    for feature in features:
-        feature = np.load(feature)
-
-        for f in feature:
-            x.append(f.mean(axis=(1, 2)))
-
-    for annotation in annotations:
-        with open(annotation, 'r') as f:
-            annotation = json.load(f)['time_annotation']
-
-        pos1 = np.where(np.array(annotation).astype(int) == 1)[0]
-
-        if len(pos1) > 0:
-            class_weight.update({1: 2})
-
-            for p in pos1:
-                if p + 1 < len(annotation):
-                    annotation[p + 1] = 1
-
-        pos1 = np.where(np.array(annotation).astype(int) == 2)[0]
-
-        if len(pos1) > 0:
-            class_weight.update({2: 2})
-
-            for p in pos1:
-                if p + 1 < len(annotation):
-                    annotation[p + 1] = 2
-
-        for a in annotation:
-            y.append(a)
-
-    x = np.array(x)
-    y = np.array(y)
+    all_features = np.array(all_features)
+    all_annotations = np.array(all_annotations)
 
     if len(class_weight) > 1:
         logreg = LogisticRegression(C=0.1, class_weight=class_weight)
-        logreg.fit(x, y)
+        logreg.fit(all_features, all_annotations)
         dump(logreg, logreg_path)

--- a/tools/train_classifier.py
+++ b/tools/train_classifier.py
@@ -130,11 +130,11 @@ def train_model(path_in, path_out, model_name, model_version, num_layers_to_fine
     label_names = [x for x in label_names if not x.startswith('.')]
 
     project_config = load_project_config(path_in)
+    label_names_temporal = ['background']
     if project_config:
         project_tags = project_config['project_tags']
-        label_names_temporal = project_tags.values()
+        label_names_temporal.extend(project_tags.values())
     else:
-        label_names_temporal = ['background']
         for label in label_names:
             label_names_temporal.extend([f'{label}_tag1', f'{label}_tag2'])
     label_names_temporal = natsorted(label_names_temporal, alg=ns.IC)

--- a/tools/train_classifier.py
+++ b/tools/train_classifier.py
@@ -132,8 +132,8 @@ def train_model(path_in, path_out, model_name, model_version, num_layers_to_fine
     project_config = load_project_config(path_in)
     label_names_temporal = ['background']
     if project_config:
-        project_tags = project_config['project_tags']
-        label_names_temporal.extend(project_tags.values())
+        tags = project_config['tags']
+        label_names_temporal.extend(tags.values())
     else:
         for label in label_names:
             label_names_temporal.extend([f'{label}_tag1', f'{label}_tag2'])

--- a/tools/train_classifier.py
+++ b/tools/train_classifier.py
@@ -132,7 +132,7 @@ def train_model(path_in, path_out, model_name, model_version, num_layers_to_fine
     project_config = load_project_config(path_in)
     if project_config:
         project_tags = project_config['project_tags']
-        label_names_temporal = project_tags.keys()
+        label_names_temporal = project_tags.values()
     else:
         label_names_temporal = ['background']
         for label in label_names:

--- a/tools/train_classifier.py
+++ b/tools/train_classifier.py
@@ -132,16 +132,15 @@ def train_model(path_in, path_out, model_name, model_version, num_layers_to_fine
     project_config = load_project_config(path_in)
     if project_config:
         project_tags = project_config['project_tags']
-        label_names_temporal = natsorted(project_tags.keys(), alg=ns.IC)
-        label2int_temporal_annotation = project_tags
+        label_names_temporal = project_tags.keys()
     else:
         label_names_temporal = ['background']
         for label in label_names:
             label_names_temporal.extend([f'{label}_tag1', f'{label}_tag2'])
-        label_names_temporal = natsorted(set(label_names_temporal), alg=ns.IC)
-        label2int_temporal_annotation = {name: index for index, name in enumerate(label_names_temporal)}
+    label_names_temporal = natsorted(label_names_temporal, alg=ns.IC)
 
     label2int = {name: index for index, name in enumerate(label_names)}
+    label2int_temporal_annotation = {name: index for index, name in enumerate(label_names_temporal)}
 
     extractor_stride = backbone_network.num_required_frames_per_layer_padding[0]
 

--- a/tools/train_classifier.py
+++ b/tools/train_classifier.py
@@ -128,19 +128,17 @@ def train_model(path_in, path_out, model_name, model_version, num_layers_to_fine
     label_names = os.listdir(directories.get_videos_dir(path_in, 'train'))
     label_names = natsorted(label_names, alg=ns.IC)
     label_names = [x for x in label_names if not x.startswith('.')]
-    label_names_temporal = []
 
     project_config = load_project_config(path_in)
     if project_config:
-        for temporal_tags in project_config['project_tags'].keys():
-            label_names_temporal.extend([temporal_tags])
-        label_names_temporal = sorted(set(label_names_temporal))
-        label2int_temporal_annotation = project_config['project_tags']
+        project_tags = project_config['project_tags']
+        label_names_temporal = natsorted(project_tags.keys(), alg=ns.IC)
+        label2int_temporal_annotation = project_tags
     else:
-        label_names_temporal.extend(['background'])
+        label_names_temporal = ['background']
         for label in label_names:
             label_names_temporal.extend([f'{label}_tag1', f'{label}_tag2'])
-        label_names_temporal = sorted(set(label_names_temporal))
+        label_names_temporal = natsorted(set(label_names_temporal), alg=ns.IC)
         label2int_temporal_annotation = {name: index for index, name in enumerate(label_names_temporal)}
 
     label2int = {name: index for index, name in enumerate(label_names)}


### PR DESCRIPTION
### Features
- Add backwards compatibility update when loading project config
  - Setup dictionary of project tags, update class tags and translate existing annotations
  - Check for all other project settings that have been added later
- Treat `background` as persistent default label
- Correctly handle tag indices that might have gaps (when tags have been removed), especially when building `label2int` dictionary
- Save `max_tag_index` so that a removed tag can not be overwritten by a new one
- Reset annotations for tags that have been removed
- Let `logreg` work on an arbitrary number of tags

### Smaller Changes
- Don't show "This tag already exists" when leaving a tag name unchanged
- Flip tag name and index in project tags dictionary for easier processing
- Sort tags by value
- Remove duplicate `FileNotFoundErrors`
- Move buttons on same line with edit field
![image](https://user-images.githubusercontent.com/5707898/117821892-4d6af780-b26c-11eb-901b-7b181f3077e1.png)
- Reset class name when editing is cancelled (similar to how it was done for tags)
- Directly send submitted forms for saving/removing project tags to the backend
