### PR TITLE
Train global logistic regression model on all available data

### DIFF
--- a/sense/finetuning.py
+++ b/sense/finetuning.py
@@ -239,6 +239,8 @@ def compute_frames_and_features(inference_engine: InferenceEngine, project_path:
     :param features_dir:
         Directory where computed features should be stored. One .npy file will be created per video.
     """
+    assisted_tagging = utils.get_project_setting(project_path, 'assisted_tagging')
+
     # Create features and frames folders
     os.makedirs(features_dir, exist_ok=True)
     os.makedirs(frames_dir, exist_ok=True)
@@ -254,8 +256,7 @@ def compute_frames_and_features(inference_engine: InferenceEngine, project_path:
         path_frames = os.path.join(frames_dir, video_name)
         path_features = os.path.join(features_dir, f'{video_name}.npy')
 
-        features_needed = (utils.get_project_setting(project_path, 'assisted_tagging')
-                           and not os.path.exists(path_features))
+        features_needed = (assisted_tagging and not os.path.exists(path_features))
 
         frames = extract_frames(video_path=video_path,
                                 inference_engine=inference_engine,

--- a/tools/directories.py
+++ b/tools/directories.py
@@ -38,11 +38,9 @@ def get_tags_dir(dataset_path, split, label=None):
     return _get_data_dir('tags', dataset_path, split, subdirs)
 
 
-def get_logreg_dir(dataset_path, model: Optional[ModelConfig] = None, label=None):
+def get_logreg_dir(dataset_path, model: Optional[ModelConfig] = None):
     subdirs = None
     if model:
         subdirs = [model.combined_model_name]
-        if label:
-            subdirs.append(label)
 
     return _get_data_dir('logreg', dataset_path, subdirs=subdirs)

--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -194,7 +194,7 @@ def train_logreg(path, label):
     """
     (Re-)Train a logistic regression model on all annotations that have been submitted so far.
     """
-    inference_engine, model_config = project_utils.load_feature_extractor(path)
+    inference_engine, model_config = utils.load_feature_extractor(path)
 
     logreg_dir = directories.get_logreg_dir(path, model_config, label)
     logreg_path = os.path.join(logreg_dir, 'logreg.joblib')

--- a/tools/sense_studio/annotation.py
+++ b/tools/sense_studio/annotation.py
@@ -182,7 +182,7 @@ def submit_annotation():
                                     features_dir=features_dir)
 
         # Re-train the logistic regression model
-        utils.train_logreg(path=path, split=split, label=label)
+        utils.train_logreg(path=path, label=label)
 
     if next_frame_idx >= len(os.listdir(frames_dir)):
         return redirect(url_for('.show_video_list', project=project, split=split, label=label))

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -263,7 +263,7 @@ def toggle_project_setting():
                                     features_dir=features_dir)
 
         # Re-train the logistic regression model
-        utils.train_logreg(path=path, split=split, label=label)
+        utils.train_logreg(path=path, label=label)
 
     return jsonify(setting_status=new_status)
 

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -20,12 +20,11 @@ from flask import request
 from flask import url_for
 
 from sense import SPLITS
-from sense.finetuning import compute_frames_and_features
 from tools import directories
 from tools.sense_studio import project_utils
 from tools.sense_studio import socketio
-from tools.sense_studio import utils
 from tools.sense_studio.annotation import annotation_bp
+from tools.sense_studio.annotation import train_logreg
 from tools.sense_studio.testing import testing_bp
 from tools.sense_studio.training import training_bp
 from tools.sense_studio.video_recording import video_recording_bp
@@ -247,23 +246,10 @@ def toggle_project_setting():
 
     # Update logreg model if assisted tagging was just enabled
     if setting == 'assisted_tagging' and new_status:
-        split = data['split']
         label = data['label']
-        inference_engine, model_config = utils.load_feature_extractor(path)
-
-        videos_dir = directories.get_videos_dir(path, split, label)
-        frames_dir = directories.get_frames_dir(path, split, label)
-        features_dir = directories.get_features_dir(path, split, model_config, label=label)
-
-        # Compute the respective frames and features
-        compute_frames_and_features(inference_engine=inference_engine,
-                                    project_path=path,
-                                    videos_dir=videos_dir,
-                                    frames_dir=frames_dir,
-                                    features_dir=features_dir)
 
         # Re-train the logistic regression model
-        utils.train_logreg(path=path, label=label)
+        train_logreg(path=path, label=label)
 
     return jsonify(setting_status=new_status)
 

--- a/tools/sense_studio/sense_studio.py
+++ b/tools/sense_studio/sense_studio.py
@@ -246,10 +246,7 @@ def toggle_project_setting():
 
     # Update logreg model if assisted tagging was just enabled
     if setting == 'assisted_tagging' and new_status:
-        label = data['label']
-
-        # Re-train the logistic regression model
-        train_logreg(path=path, label=label)
+        train_logreg(path=path)
 
     return jsonify(setting_status=new_status)
 
@@ -289,10 +286,6 @@ def edit_class(project, class_name):
             data_dirs.extend([os.path.join(model_dir, tuned_layers)
                               for model_dir in model_dirs
                               for tuned_layers in os.listdir(model_dir)])
-
-    logreg_dir = directories.get_logreg_dir(path)
-    if os.path.exists(logreg_dir):
-        data_dirs.extend([os.path.join(logreg_dir, model_dir) for model_dir in os.listdir(logreg_dir)])
 
     for base_dir in data_dirs:
         class_dir = os.path.join(base_dir, class_name)

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -333,9 +333,8 @@ async function toggleMakeProjectTemporal(path) {
 }
 
 
-async function toggleAssistedTagging(path, label) {
-    let response = await asyncRequest('/toggle-project-setting',
-                                      {path: path, setting: 'assisted_tagging', label: label});
+async function toggleAssistedTagging(path) {
+    let response = await asyncRequest('/toggle-project-setting', {path: path, setting: 'assisted_tagging'});
 
     // Reload page to update predictions
     window.location.reload();

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -333,9 +333,9 @@ async function toggleMakeProjectTemporal(path) {
 }
 
 
-async function toggleAssistedTagging(path, split, label) {
+async function toggleAssistedTagging(path, label) {
     let response = await asyncRequest('/toggle-project-setting',
-                                      {path: path, setting: 'assisted_tagging', split: split, label: label});
+                                      {path: path, setting: 'assisted_tagging', label: label});
 
     // Reload page to update predictions
     window.location.reload();

--- a/tools/sense_studio/static/main.js
+++ b/tools/sense_studio/static/main.js
@@ -250,7 +250,7 @@ function getProjectConfig(projectName) {
 }
 
 
-function loading(element, message, url) {
+function loadingButton(element, message, url) {
     let icon = element.children[0];
     let text = element.children[1];
 
@@ -262,6 +262,12 @@ function loading(element, message, url) {
     if (url) {
         window.location = url;
     }
+}
+
+
+function loadingLink(element) {
+    element.setAttribute('uk-spinner', 'ratio: 0.6');
+    element.innerHTML = '';
 }
 
 
@@ -334,6 +340,12 @@ async function toggleMakeProjectTemporal(path) {
 
 
 async function toggleAssistedTagging(path) {
+    let checkbox = document.getElementById('assistedTaggingCheckbox');
+    let spinner = document.getElementById('assistedTaggingSpinner');
+
+    checkbox.classList.add('uk-hidden');
+    spinner.classList.remove('uk-hidden');
+
     let response = await asyncRequest('/toggle-project-setting', {path: path, setting: 'assisted_tagging'});
 
     // Reload page to update predictions

--- a/tools/sense_studio/templates/frame_annotation.html
+++ b/tools/sense_studio/templates/frame_annotation.html
@@ -35,7 +35,7 @@
                     <label uk-tooltip="Train a simple logistic regression model live on temporal annotations and show current predictions">
                         <input type="checkbox" class="uk-checkbox"
                                {% if project_config.assisted_tagging %} checked {% endif %}
-                               onclick="toggleAssistedTagging('{{ path }}', '{{ label }}');">
+                               onclick="toggleAssistedTagging('{{ path }}');">
                         Assisted Tagging
                     </label>
                 </div>

--- a/tools/sense_studio/templates/frame_annotation.html
+++ b/tools/sense_studio/templates/frame_annotation.html
@@ -35,7 +35,7 @@
                     <label uk-tooltip="Train a simple logistic regression model live on temporal annotations and show current predictions">
                         <input type="checkbox" class="uk-checkbox"
                                {% if project_config.assisted_tagging %} checked {% endif %}
-                               onclick="toggleAssistedTagging('{{ path }}', '{{ split }}', '{{ label }}');">
+                               onclick="toggleAssistedTagging('{{ path }}', '{{ label }}');">
                         Assisted Tagging
                     </label>
                 </div>

--- a/tools/sense_studio/templates/frame_annotation.html
+++ b/tools/sense_studio/templates/frame_annotation.html
@@ -33,9 +33,10 @@
 
                 <div>
                     <label uk-tooltip="Train a simple logistic regression model live on temporal annotations and show current predictions">
-                        <input type="checkbox" class="uk-checkbox"
+                        <input type="checkbox" id="assistedTaggingCheckbox" class="uk-checkbox"
                                {% if project_config.assisted_tagging %} checked {% endif %}
                                onclick="toggleAssistedTagging('{{ path }}');">
+                        <span id="assistedTaggingSpinner" uk-spinner="ratio: 0.535" class="uk-hidden"></span>
                         Assisted Tagging
                     </label>
                 </div>

--- a/tools/sense_studio/templates/navigation.html
+++ b/tools/sense_studio/templates/navigation.html
@@ -51,7 +51,8 @@
                     {% if project_config.classes %}
                         {% for label, _ in project_config.classes|dictsort  %}
                             <li>
-                                <a href="{{ url_for('annotation_bp.show_video_list', project=project, split='train', label=label)}}" class="item">
+                                <a href="{{ url_for('annotation_bp.show_video_list', project=project, split='train', label=label)}}"
+                                   class="item" onclick="loadingLink(this);">
                                     {{ label }}
                                 </a>
                             </li>
@@ -65,7 +66,8 @@
                     {% if project_config.classes %}
                         {% for label, _ in project_config.classes|dictsort %}
                             <li>
-                                <a href="{{ url_for('annotation_bp.show_video_list', project=project, split='valid', label=label)}}" class="item">
+                                <a href="{{ url_for('annotation_bp.show_video_list', project=project, split='valid', label=label)}}"
+                                   class="item" onclick="loadingLink(this);">
                                     {{ label }}
                                 </a>
                             </li>

--- a/tools/sense_studio/templates/project_details.html
+++ b/tools/sense_studio/templates/project_details.html
@@ -287,7 +287,7 @@
                                 Record
                             </a>
                             <button class="uk-button uk-button-default temporal {{ 'uk-hidden' if not config.temporal }}"
-                               onclick="loading(this, 'Preparing', '{{ url_for('annotation_bp.show_video_list', project=project, split='train', label=class) }}');">
+                               onclick="loadingButton(this, 'Preparing', '{{ url_for('annotation_bp.show_video_list', project=project, split='train', label=class) }}');">
                                 <span uk-icon="icon: file-edit"></span>
                                 <span>Annotate</span>
                             </button>
@@ -305,7 +305,7 @@
                                 Record
                             </a>
                             <button class="uk-button uk-button-default temporal {{ 'uk-hidden' if not config.temporal }}"
-                               onclick="loading(this, 'Preparing', '{{ url_for('annotation_bp.show_video_list', project=project, split='valid', label=class) }}');">
+                               onclick="loadingButton(this, 'Preparing', '{{ url_for('annotation_bp.show_video_list', project=project, split='valid', label=class) }}');">
                                 <span uk-icon="icon: file-edit"></span>
                                 <span>Annotate</span>
                             </button>

--- a/tools/sense_studio/utils.py
+++ b/tools/sense_studio/utils.py
@@ -1,17 +1,8 @@
-import json
-import numpy as np
-import os
-
-from joblib import dump
-from sklearn.linear_model import LogisticRegression
-
-from sense import SPLITS
 from sense.engine import InferenceEngine
 from sense.loading import build_backbone_network
 from sense.loading import get_relevant_weights
 from sense.loading import ModelConfig
-from tools import directories
-from tools.sense_studio.project_utils import load_project_config
+
 from tools.sense_studio.project_utils import get_project_setting
 
 SUPPORTED_MODEL_CONFIGURATIONS = [
@@ -47,54 +38,3 @@ def load_feature_extractor(project_path):
 def is_image_file(filename):
     """ Returns `True` if the file has a valid image extension. """
     return '.' in filename and filename.rsplit('.', 1)[1] in ('png', 'jpg', 'jpeg', 'gif', 'bmp')
-
-
-def train_logreg(path, label):
-    """
-    (Re-)Train a logistic regression model on all annotations that have been submitted so far.
-    """
-    _, model_config = load_feature_extractor(path)
-
-    logreg_dir = directories.get_logreg_dir(path, model_config, label)
-    logreg_path = os.path.join(logreg_dir, 'logreg.joblib')
-    project_config = load_project_config(path)
-    class_tags = project_config['classes'][label]
-
-    all_features = []
-    all_annotations = []
-
-    for split in SPLITS:
-        features_dir = directories.get_features_dir(path, split, model_config, label=label)
-        tags_dir = directories.get_tags_dir(path, split, label)
-
-        if not os.path.exists(tags_dir):
-            continue
-
-        video_tag_files = os.listdir(tags_dir)
-
-        for video_tag_file in video_tag_files:
-            feature_file = os.path.join(features_dir, video_tag_file.replace('.json', '.npy'))
-            annotation_file = os.path.join(tags_dir, video_tag_file)
-
-            features = np.load(feature_file)
-            for f in features:
-                all_features.append(f.mean(axis=(1, 2)))
-
-            with open(annotation_file, 'r') as f:
-                all_annotations.extend(json.load(f)['time_annotation'])
-
-    # Reset tags that have been removed from the class to 'background'
-    all_annotations = [tag_idx if tag_idx in class_tags else 0 for tag_idx in all_annotations]
-
-    # Use low class weight for background and higher weight for all present tags
-    annotated_tags = set(all_annotations)
-    class_weight = {tag: 2 for tag in annotated_tags}
-    class_weight[0] = 0.5
-
-    all_features = np.array(all_features)
-    all_annotations = np.array(all_annotations)
-
-    if len(annotated_tags) > 1:
-        logreg = LogisticRegression(C=0.1, class_weight=class_weight)
-        logreg.fit(all_features, all_annotations)
-        dump(logreg, logreg_path)


### PR DESCRIPTION
Before, one logistic regression would be trained per class and only on the data of the split (test or validation) that was just submitted. Because tags are now globally defined and can be present in multiple classes, it makes more sense to have one global logistic regression model as well. Also we can use both data from training and validation, because this is just used for assisting the user with annotation.

### Details
- `train_logreg` collects data from both splits and all classes
- The call to `compute_frames_and_features` was moved into `train_logreg`, because both calling methods were doing the same operations before
- `train_logreg` was moved into `annotation.py` to prevent the cyclic import `finetuning` -> `utils` -> `finetuning`
- Toggling the `assisted_tagging` flag no longer needs the `split` or `label` information
- The spinner animation was added to all places where there could be a delay because of assisted tagging and its preparation (the assisted tagging checkbox and the annotation navigation menu)
- `compute_frames_and_features` now makes only one call to `get_project_setting`