### PR TITLE
Add WLASL preview to gallery

### DIFF
--- a/docs/wiki/gallery.md
+++ b/docs/wiki/gallery.md
@@ -44,3 +44,14 @@ See this [post](https://corneliusboehm.github.io/sense/2021/05/14/volleyball.htm
     <img src="https://raw.githubusercontent.com/corneliusboehm/sense/master/docs/gifs/volleyball_classification_short.gif" width="400px">
     <img src="https://raw.githubusercontent.com/corneliusboehm/sense/master/docs/gifs/volleyball_counting_short.gif" width="400px">
 </p>
+
+
+### Word-level American Sign Language (preview)
+
+A word-level sign language detector was trained with a small subset (~15 words) from the 
+[WLASL dataset](https://dxli94.github.io/WLASL/) which contains over 2,000 words. Training a larger
+model is in progress but here's a quick preview of what was achieved with a tiny subset. 
+
+<p align="center">
+    <img src="https://raw.githubusercontent.com/sunny-panchal/sense/demo/wlasl/docs/gifs/wlasl_v1.gif" width="400px">
+</p>


### PR DESCRIPTION
This PR adds a preview gif of the word-level American sign language project to the gallery.