### PR TITLE
Add explanation on expected camera and model FPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,17 @@ needs to be downloaded separately.
 ## Getting Started
 To get started, try out the demos we've provided. Inside the `sense/examples` directory, you will find multiple Python scripts 
 that each apply our pre-trained models to a specific use-case. Launching each demo is as simple as running the script in terminal 
-as described below. 
+as described below.
+
+The examples will display information on the achieved frame rate in the lower left corner, so you can verify that your
+installation is running well.
+- `Camera FPS` is the rate at which frames are read from the webcam or from the provided file. Per default, 16fps is the
+maximum that was configured as a trade-off between high input frame rate and low computational footprint of the model.
+  The input video stream will be up- or down-sampled accordingly, so that all processing happens in real-time.
+- `Model FPS` is the rate at which the model produces predictions. In order to keep computations low, our model always
+  collects four frames before passing them through the network, so the expected output frame rate is 4fps. Through temporal
+  convolutions with striding, the model still maintains a larger receptive field.
+
 
 #### Demo 1: Action Recognition
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ See all available install commands [here](https://pytorch.org/).
 #### Step 3: Download the SenseKit Weights
 Pre-trained weights can be downloaded from [here](https://20bn.com/licensing/sdk/evaluation), subject to separate terms. 
 Follow the instructions to create an account, agree to evaluation license and download the weights. Once downloaded, unzip the folder and move the 
-folder named `backbone` into `sense/resources`. In the end, your resources folder structure should look like
- this:
+contents into `sense/resources`. In the end, your resources folder structure should look like this:
 
 ```
 resources
@@ -122,8 +121,8 @@ resources
 └── ...
 ```
 
-Note: The remaining folders in `resources/` will already have the necessary files -- only `resources/backbone` 
-needs to be downloaded separately. 
+Note: The remaining folders in `resources/` will already have the necessary files -- only some additional larger folders
+need to be downloaded separately.
 
 --- 
 


### PR DESCRIPTION
Add information on the expected camera and model FPS to the README, because there has been confusion about which values should be achieved for real-time processing.

Also generalize the instructions on extracting additional resource folders, because now the download contains multiple ones.

Closes #175 